### PR TITLE
RDKOSS-82 Remove RDM from package group

### DIFF
--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -309,7 +309,6 @@ RDEPENDS:${PN} += "\
      pango \
      procps \
      rdkperf \
-     rdm \
      readline \
      safec-common-wrapper \
      sed \


### PR DESCRIPTION
RDM component is not open sourced yet. Therefore removing it