### PR TITLE
RDKEMW-1708: Update logging level in NetworkManager

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -653,7 +653,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r0"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r1"
+PR:pn-networkmanager = "r2"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/95-logging.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/95-logging.conf
@@ -1,4 +1,4 @@
 [logging]
-level=DEBUG
+level=INFO
 domains=ALL
 


### PR DESCRIPTION
Reason for change: NetworkManager is now defaulted in RDKE.
Reduce Logging level to prevent excessive printing.
Debug logs can be enabled as needed.
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)