### PR TITLE
RDKEMW-1708: Update logging level in NetworkManager

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -622,7 +622,7 @@ PACKAGE_ARCH_pn-netbase = "${OSS_LAYER_ARCH}"
 PR_pn-nettle = "r0"
 PACKAGE_ARCH_pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR_pn-networkmanager = "r1"
+PR_pn-networkmanager = "r2"
 PACKAGE_ARCH_pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR_pn-nghttp2 = "r0"

--- a/recipes-connectivity/networkmanager/networkmanager/95-logging.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/95-logging.conf
@@ -1,4 +1,4 @@
 [logging]
-level=DEBUG
+level=INFO
 domains=ALL
 


### PR DESCRIPTION
Reason for change: NetworkManager is now defaulted in RDKE.
Reduce Logging level to prevent excessive printing.
Debug logs can be enabled as needed.
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)