### PR TITLE
RDK-55527 : Patching CVEs for pixman, libarchive, bind, redis, libpam, gmp

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -101,7 +101,7 @@ PACKAGE_ARCH:pn-bash = "${OSS_LAYER_ARCH}"
 PR:pn-bash-completion = "r0"
 PACKAGE_ARCH:pn-bash-completion = "${OSS_LAYER_ARCH}"
 
-PR:pn-bind = "r0"
+PR:pn-bind = "r1"
 PACKAGE_ARCH:pn-bind = "${OSS_LAYER_ARCH}"
 
 PR:pn-boost = "r0"
@@ -254,7 +254,7 @@ PACKAGE_ARCH:pn-glib-networking = "${OSS_LAYER_ARCH}"
 PR:pn-openssh = "r0"
 PACKAGE_ARCH:pn-openssh = "${OSS_LAYER_ARCH}"
 
-PR:pn-gmp = "r0"
+PR:pn-gmp = "r1"
 PACKAGE_ARCH:pn-gmp = "${OSS_LAYER_ARCH}"
 
 PR:pn-gnutls = "r1"
@@ -338,7 +338,7 @@ PACKAGE_ARCH:pn-lcms = "${OSS_LAYER_ARCH}"
 PR:pn-libaio = "r0"
 PACKAGE_ARCH:pn-libaio = "${OSS_LAYER_ARCH}"
 
-PR:pn-libarchive = "r0"
+PR:pn-libarchive = "r1"
 PACKAGE_ARCH:pn-libarchive = "${OSS_LAYER_ARCH}"
 
 PR:pn-libatomic-ops = "r0"
@@ -458,7 +458,7 @@ PACKAGE_ARCH:pn-libomxil = "${OSS_LAYER_ARCH}"
 PR:pn-libopus = "r0"
 PACKAGE_ARCH:pn-libopus = "${OSS_LAYER_ARCH}"
 
-PR:pn-libpam = "r0"
+PR:pn-libpam = "r1"
 PACKAGE_ARCH:pn-libpam = "${OSS_LAYER_ARCH}"
 
 PR:pn-libpcap = "r1"
@@ -695,7 +695,7 @@ PACKAGE_ARCH:pn-orc = "${OSS_LAYER_ARCH}"
 PR:pn-perl = "r1"
 PACKAGE_ARCH:pn-perl = "${OSS_LAYER_ARCH}"
 
-PR:pn-pixman = "r0"
+PR:pn-pixman = "r1"
 PACKAGE_ARCH:pn-pixman = "${OSS_LAYER_ARCH}"
 
 PR:pn-popt = "r0"
@@ -741,7 +741,7 @@ PACKAGE_ARCH:pn-re2 = "${OSS_LAYER_ARCH}"
 PR:pn-readline = "r9"
 PACKAGE_ARCH:pn-readline = "${OSS_LAYER_ARCH}"
 
-PR:pn-redis = "r1"
+PR:pn-redis = "r2"
 PACKAGE_ARCH:pn-redis = "${OSS_LAYER_ARCH}"
 
 PR:pn-run-postinsts = "r10"

--- a/recipes-connectivity/bind/bind_9.18.5.bbappend
+++ b/recipes-connectivity/bind/bind_9.18.5.bbappend
@@ -10,6 +10,9 @@ SRC_URI:append = "file://CVE-2022-2795_9.18.5_fix.patch \
                   file://CVE-2023-3341_9.18.5_fix.patch \
                   file://CVE-2023-4236_9.18.5_fix.patch \
                   file://CVE-2023-50387_9.18.5_fix.patch \
+                  file://CVE-2023-2828_9.18.5_fix.patch \
+                  file://CVE-2023-5517_9.18.5_fix.patch \
+                  file://CVE-2023-5679_9.18.5_fix.patch \
                  "
 
 

--- a/recipes-connectivity/bind/bind_9.18.5.bbappend
+++ b/recipes-connectivity/bind/bind_9.18.5.bbappend
@@ -10,9 +10,4 @@ SRC_URI:append = "file://CVE-2022-2795_9.18.5_fix.patch \
                   file://CVE-2023-3341_9.18.5_fix.patch \
                   file://CVE-2023-4236_9.18.5_fix.patch \
                   file://CVE-2023-50387_9.18.5_fix.patch \
-                  file://CVE-2023-2828_9.18.5_fix.patch \
-                  file://CVE-2023-5517_9.18.5_fix.patch \
-                  file://CVE-2023-5679_9.18.5_fix.patch \
                  "
-
-

--- a/recipes-connectivity/bind/bind_9.18.5.bbappend
+++ b/recipes-connectivity/bind/bind_9.18.5.bbappend
@@ -11,3 +11,5 @@ SRC_URI:append = "file://CVE-2022-2795_9.18.5_fix.patch \
                   file://CVE-2023-4236_9.18.5_fix.patch \
                   file://CVE-2023-50387_9.18.5_fix.patch \
                  "
+
+

--- a/recipes-connectivity/bind/files/CVE-2023-2828_9.18.5_fix.patch
+++ b/recipes-connectivity/bind/files/CVE-2023-2828_9.18.5_fix.patch
@@ -1,0 +1,163 @@
+Subject: [PATCH] 
+Date: May 6, 2024 
+From: srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://downloads.isc.org/isc/bind9/9.18.16/patches/0001-CVE-2023-2828.patch
+
+diff --git a/lib/dns/rbtdb.c b/lib/dns/rbtdb.c
+index 29dce2e..199c46b 100644
+--- a/lib/dns/rbtdb.c
++++ b/lib/dns/rbtdb.c
+@@ -554,7 +554,7 @@ static void
+ expire_header(dns_rbtdb_t *rbtdb, rdatasetheader_t *header, bool tree_locked,
+ 	      expire_t reason);
+ static void
+-overmem_purge(dns_rbtdb_t *rbtdb, unsigned int locknum_start, isc_stdtime_t now,
++overmem_purge(dns_rbtdb_t *rbtdb, unsigned int locknum_start, size_t purgesize,
+ 	      bool tree_locked);
+ static void
+ resign_insert(dns_rbtdb_t *rbtdb, int idx, rdatasetheader_t *newheader);
+@@ -6724,6 +6724,16 @@ cleanup:
+ 
+ static dns_dbmethods_t zone_methods;
+ 
++static size_t
++rdataset_size(rdatasetheader_t *header) {
++	if (!NONEXISTENT(header)) {
++		return (dns_rdataslab_size((unsigned char *)header,
++					   sizeof(*header)));
++	}
++
++	return (sizeof(*header));
++}
++
+ static isc_result_t
+ addrdataset(dns_db_t *db, dns_dbnode_t *node, dns_dbversion_t *version,
+ 	    isc_stdtime_t now, dns_rdataset_t *rdataset, unsigned int options,
+@@ -6887,7 +6897,8 @@ addrdataset(dns_db_t *db, dns_dbnode_t *node, dns_dbversion_t *version,
+ 	}
+ 
+ 	if (cache_is_overmem) {
+-		overmem_purge(rbtdb, rbtnode->locknum, now, tree_locked);
++		overmem_purge(rbtdb, rbtnode->locknum, rdataset_size(newheader),
++			      tree_locked);
+ 	}
+ 
+ 	NODE_LOCK(&rbtdb->node_locks[rbtnode->locknum].lock,
+@@ -6906,10 +6917,18 @@ addrdataset(dns_db_t *db, dns_dbnode_t *node, dns_dbversion_t *version,
+ 		}
+ 
+ 		header = isc_heap_element(rbtdb->heaps[rbtnode->locknum], 1);
+-		if (header != NULL && header->rdh_ttl + rbtdb->serve_stale_ttl <
+-					      now - RBTDB_VIRTUAL)
+-		{
+-			expire_header(rbtdb, header, tree_locked, expire_ttl);
++                if (header != NULL) {
++			dns_ttl_t rdh_ttl = header->rdh_ttl;
++
++			/* Only account for stale TTL if cache is not overmem */
++			if (!cache_is_overmem) {
++				rdh_ttl += rbtdb->serve_stale_ttl;
++			}
++
++			if (rdh_ttl < now - RBTDB_VIRTUAL) {
++				expire_header(rbtdb, header, tree_locked,
++					      expire_ttl);
++			}
+ 		}
+ 
+ 		/*
+@@ -10020,53 +10039,59 @@ update_header(dns_rbtdb_t *rbtdb, rdatasetheader_t *header, isc_stdtime_t now) {
+ 	header->last_used = now;
+ 	ISC_LIST_PREPEND(rbtdb->rdatasets[header->node->locknum], header, link);
+ }
++static size_t
++expire_lru_headers(dns_rbtdb_t *rbtdb, unsigned int locknum, size_t purgesize,
++		   bool tree_locked) {
++	rdatasetheader_t *header, *header_prev;
++	size_t purged = 0;
++
++	for (header = ISC_LIST_TAIL(rbtdb->rdatasets[locknum]);
++	     header != NULL && purged <= purgesize; header = header_prev)
++	{
++		header_prev = ISC_LIST_PREV(header, link);
++		/*
++		 * Unlink the entry at this point to avoid checking it
++		 * again even if it's currently used someone else and
++		 * cannot be purged at this moment.  This entry won't be
++		 * referenced any more (so unlinking is safe) since the
++		 * TTL was reset to 0.
++		 */
++		ISC_LIST_UNLINK(rbtdb->rdatasets[locknum], header, link);
++		size_t header_size = rdataset_size(header);
++		expire_header(rbtdb, header, tree_locked, expire_lru);
++		purged += header_size;
++	}
++
++	return (purged);
++}
++
+ 
+ /*%
+- * Purge some expired and/or stale (i.e. unused for some period) cache entries
+- * under an overmem condition.  To recover from this condition quickly, up to
+- * 2 entries will be purged.  This process is triggered while adding a new
+- * entry, and we specifically avoid purging entries in the same LRU bucket as
+- * the one to which the new entry will belong.  Otherwise, we might purge
+- * entries of the same name of different RR types while adding RRsets from a
+- * single response (consider the case where we're adding A and AAAA glue records
+- * of the same NS name).
++ * Purge some stale (i.e. unused for some period - LRU based cleaning) cache
++ * entries under the overmem condition.  To recover from this condition quickly,
++ * we cleanup entries up to the size of newly added rdata (passed as purgesize).
++ *
++ * This process is triggered while adding a new entry, and we specifically avoid
++ * purging entries in the same LRU bucket as the one to which the new entry will
++ * belong.  Otherwise, we might purge entries of the same name of different RR
++ * types while adding RRsets from a single response (consider the case where
++ * we're adding A and AAAA glue records of the same NS name).
+  */
+ static void
+-overmem_purge(dns_rbtdb_t *rbtdb, unsigned int locknum_start, isc_stdtime_t now,
++overmem_purge(dns_rbtdb_t *rbtdb, unsigned int locknum_start, size_t purgesize,
+ 	      bool tree_locked) {
+-	rdatasetheader_t *header, *header_prev;
+ 	unsigned int locknum;
+-	int purgecount = 2;
++        size_t purged = 0;
+ 
+ 	for (locknum = (locknum_start + 1) % rbtdb->node_lock_count;
+-	     locknum != locknum_start && purgecount > 0;
++	     locknum != locknum_start && purged <= purgesize;
+ 	     locknum = (locknum + 1) % rbtdb->node_lock_count)
+ 	{
+ 		NODE_LOCK(&rbtdb->node_locks[locknum].lock,
+ 			  isc_rwlocktype_write);
+ 
+-		header = isc_heap_element(rbtdb->heaps[locknum], 1);
+-		if (header && header->rdh_ttl < now - RBTDB_VIRTUAL) {
+-			expire_header(rbtdb, header, tree_locked, expire_ttl);
+-			purgecount--;
+-		}
+-
+-		for (header = ISC_LIST_TAIL(rbtdb->rdatasets[locknum]);
+-		     header != NULL && purgecount > 0; header = header_prev)
+-		{
+-			header_prev = ISC_LIST_PREV(header, link);
+-			/*
+-			 * Unlink the entry at this point to avoid checking it
+-			 * again even if it's currently used someone else and
+-			 * cannot be purged at this moment.  This entry won't be
+-			 * referenced any more (so unlinking is safe) since the
+-			 * TTL was reset to 0.
+-			 */
+-			ISC_LIST_UNLINK(rbtdb->rdatasets[locknum], header,
+-					link);
+-			expire_header(rbtdb, header, tree_locked, expire_lru);
+-			purgecount--;
+-		}
++                purged += expire_lru_headers(rbtdb, locknum, purgesize - purged,
++					     tree_locked);
+ 
+ 		NODE_UNLOCK(&rbtdb->node_locks[locknum].lock,
+ 			    isc_rwlocktype_write);

--- a/recipes-connectivity/bind/files/CVE-2023-5517_9.18.5_fix.patch
+++ b/recipes-connectivity/bind/files/CVE-2023-5517_9.18.5_fix.patch
@@ -1,0 +1,100 @@
+From 66e6b6b6cc370d27ce3cdeb05aa226caaec79526 Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://ftp.isc.org/isc/bind9/9.18.24/patches/0002-CVE-2023-5517.patch
+CVE:CVE-2023-5517
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ lib/ns/query.c | 22 ++++++++++------------
+ 1 file changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/lib/ns/query.c b/lib/ns/query.c
+index 30504ba..0ed732d 100644
+--- a/lib/ns/query.c
++++ b/lib/ns/query.c
+@@ -465,10 +465,10 @@ static void
+ query_addnxrrsetnsec(query_ctx_t *qctx);
+ 
+ static isc_result_t
+-query_nxdomain(query_ctx_t *qctx, isc_result_t res);
++query_nxdomain(query_ctx_t *qctx, isc_result_t result);
+ 
+ static isc_result_t
+-query_redirect(query_ctx_t *qctx);
++query_redirect(query_ctx_t *qctx, isc_result_t result);
+ 
+ static isc_result_t
+ query_ncache(query_ctx_t *qctx, isc_result_t result);
+@@ -7602,8 +7602,7 @@ query_usestale(query_ctx_t *qctx, isc_result_t result) {
+  * result from the search.
+  */
+ static isc_result_t
+-query_gotanswer(query_ctx_t *qctx, isc_result_t res) {
+-	isc_result_t result = res;
++query_gotanswer(query_ctx_t *qctx, isc_result_t result) {
+ 	char errmsg[256];
+ 
+ 	CCTRACE(ISC_LOG_DEBUG(3), "query_gotanswer");
+@@ -7679,7 +7678,7 @@ root_key_sentinel:
+ 		return (query_coveringnsec(qctx));
+ 
+ 	case DNS_R_NCACHENXDOMAIN:
+-		result = query_redirect(qctx);
++		result = query_redirect(qctx, result);
+ 		if (result != ISC_R_COMPLETE) {
+ 			return (result);
+ 		}
+@@ -9489,11 +9488,10 @@ query_addnxrrsetnsec(query_ctx_t *qctx) {
+  * Handle NXDOMAIN and empty wildcard responses.
+  */
+ static isc_result_t
+-query_nxdomain(query_ctx_t *qctx, isc_result_t res) {
++query_nxdomain(query_ctx_t *qctx, isc_result_t result) {
+ 	dns_section_t section;
+ 	uint32_t ttl;
+-	isc_result_t result = res;
+-	bool empty_wild = (res == DNS_R_EMPTYWILD);
++	bool empty_wild = (result == DNS_R_EMPTYWILD);
+ 
+ 	CCTRACE(ISC_LOG_DEBUG(3), "query_nxdomain");
+ 
+@@ -9502,7 +9500,7 @@ query_nxdomain(query_ctx_t *qctx, isc_result_t res) {
+ 	INSIST(qctx->is_zone || REDIRECT(qctx->client));
+ 
+ 	if (!empty_wild) {
+-		result = query_redirect(qctx);
++		result = query_redirect(qctx, result);
+ 		if (result != ISC_R_COMPLETE) {
+ 			return (result);
+ 		}
+@@ -9588,7 +9586,7 @@ cleanup:
+  * redirecting, so query processing should continue past it.
+  */
+ static isc_result_t
+-query_redirect(query_ctx_t *qctx) {
++query_redirect(query_ctx_t *qctx, isc_result_t saved_result) {
+ 	isc_result_t result;
+ 
+ 	CCTRACE(ISC_LOG_DEBUG(3), "query_redirect");
+@@ -9629,7 +9627,7 @@ query_redirect(query_ctx_t *qctx) {
+ 		SAVE(qctx->client->query.redirect.rdataset, qctx->rdataset);
+ 		SAVE(qctx->client->query.redirect.sigrdataset,
+ 		     qctx->sigrdataset);
+-		qctx->client->query.redirect.result = DNS_R_NCACHENXDOMAIN;
++		qctx->client->query.redirect.result = saved_result;
+ 		dns_name_copy(qctx->fname, qctx->client->query.redirect.fname);
+ 		qctx->client->query.redirect.authoritative =
+ 			qctx->authoritative;
+@@ -10283,7 +10281,7 @@ query_coveringnsec(query_ctx_t *qctx) {
+ 	 * We now have the proof that we have an NXDOMAIN.  Apply
+ 	 * NXDOMAIN redirection if configured.
+ 	 */
+-	result = query_redirect(qctx);
++	result = query_redirect(qctx, DNS_R_COVERINGNSEC);
+ 	if (result != ISC_R_COMPLETE) {
+ 		redirected = true;
+ 		goto cleanup;

--- a/recipes-connectivity/bind/files/CVE-2023-5679_9.18.5_fix.patch
+++ b/recipes-connectivity/bind/files/CVE-2023-5679_9.18.5_fix.patch
@@ -1,0 +1,32 @@
+From 972c703466702b0796504f2db45f951a1c92b1ba Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://ftp.isc.org/isc/bind9/9.18.24/patches/0003-CVE-2023-5679.patch
+ CVE:CVE-2023-5679
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ lib/ns/query.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/lib/ns/query.c b/lib/ns/query.c
+index bdd3d94..30504ba 100644
+--- a/lib/ns/query.c
++++ b/lib/ns/query.c
+@@ -6140,6 +6140,13 @@ query_lookup_stale(ns_client_t *client) {
+ 	query_ctx_t qctx;
+ 
+ 	qctx_init(client, NULL, client->query.qtype, &qctx);
++	if (DNS64(client)) {
++		qctx.qtype = qctx.type = dns_rdatatype_a;
++		qctx.dns64 = true;
++	}
++	if (DNS64EXCLUDE(client)) {
++		qctx.dns64_exclude = true;
++	}
+ 	dns_db_attach(client->view->cachedb, &qctx.db);
+ 	client->query.attributes &= ~NS_QUERYATTR_RECURSIONOK;
+ 	client->query.dboptions |= DNS_DBFIND_STALETIMEOUT;

--- a/recipes-extended/pam/libpam/CVE-2024-10041_1.5.2_fix.patch
+++ b/recipes-extended/pam/libpam/CVE-2024-10041_1.5.2_fix.patch
@@ -1,0 +1,50 @@
+From 8a97e5f5323d8ce69d817909164256487b89047d Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/linux-pam/linux-pam/pull/686/commits/b3020da7da384d769f27a8713257fbe1001878be
+CVE : CVE-2024-10041
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ modules/pam_unix/passverify.c | 21 +++++++++++----------
+ 1 file changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/modules/pam_unix/passverify.c b/modules/pam_unix/passverify.c
+index f2474a5..b300522 100644
+--- a/modules/pam_unix/passverify.c
++++ b/modules/pam_unix/passverify.c
+@@ -237,20 +237,21 @@ PAMH_ARG_DECL(int get_account_info,
+ 			return PAM_UNIX_RUN_HELPER;
+ #endif
+ 		} else if (is_pwd_shadowed(*pwd)) {
++#ifdef HELPER_COMPILE
+ 			/*
+-			 * ...and shadow password file entry for this user,
++			 * shadow password file entry for this user,
+ 			 * if shadowing is enabled
+ 			 */
+-			*spwdent = pam_modutil_getspnam(pamh, name);
+-			if (*spwdent == NULL) {
+-#ifndef HELPER_COMPILE
+-				/* still a chance the user can authenticate */
+-				return PAM_UNIX_RUN_HELPER;
+-#endif
+-				return PAM_AUTHINFO_UNAVAIL;
+-			}
+-			if ((*spwdent)->sp_pwdp == NULL)
++			*spwdent = getspnam(name);
++			if (*spwdent == NULL || (*spwdent)->sp_pwdp == NULL)
+ 				return PAM_AUTHINFO_UNAVAIL;
++#else
++			/*
++			 * The helper has to be invoked to deal with
++			 * the shadow password file entry.
++			 */
++			return PAM_UNIX_RUN_HELPER;
++#endif
+ 		}
+ 	} else {
+ 		return PAM_USER_UNKNOWN;

--- a/recipes-extended/pam/libpam_1.5.2.bbappend
+++ b/recipes-extended/pam/libpam_1.5.2.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://CVE-2024-10041_1.5.2_fix.patch \
+                 "

--- a/recipes-extended/redis/redis/CVE-2022-35977_7.0.4_fix.patch
+++ b/recipes-extended/redis/redis/CVE-2022-35977_7.0.4_fix.patch
@@ -1,0 +1,122 @@
+From dbb499a05d7f71ae3bacde3ea03cd67e5c164d07 Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/redis/redis/commit/1ec82e6e97e1db06a72ca505f9fbf6b981f31ef7
+CVE: CVE-2022-35977
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ src/sort.c                 |  6 ++++--
+ src/t_string.c             | 17 +++++++++++------
+ tests/unit/sort.tcl        | 11 +++++++++++
+ tests/unit/type/string.tcl | 10 ++++++++++
+ 4 files changed, 36 insertions(+), 8 deletions(-)
+
+diff --git a/src/sort.c b/src/sort.c
+index 62e7ad7..ecaca5a 100644
+--- a/src/sort.c
++++ b/src/sort.c
+@@ -328,8 +328,10 @@ void sortCommandGeneric(client *c, int readonly) {
+     default: vectorlen = 0; serverPanic("Bad SORT type"); /* Avoid GCC warning */
+     }
+ 
+-    /* Perform LIMIT start,count sanity checking. */
+-    start = (limit_start < 0) ? 0 : limit_start;
++    /* Perform LIMIT start,count sanity checking.
++     * And avoid integer overflow by limiting inputs to object sizes. */
++    start = min(max(limit_start, 0), vectorlen);
++    limit_count = min(max(limit_count, -1), vectorlen);
+     end = (limit_count < 0) ? vectorlen-1 : start+limit_count-1;
+     if (start >= vectorlen) {
+         start = vectorlen-1;
+diff --git a/src/t_string.c b/src/t_string.c
+index 7b67b78..24f6d01 100644
+--- a/src/t_string.c
++++ b/src/t_string.c
+@@ -37,8 +37,14 @@ int getGenericCommand(client *c);
+  * String Commands
+  *----------------------------------------------------------------------------*/
+ 
+-static int checkStringLength(client *c, long long size) {
+-    if (!mustObeyClient(c) && size > server.proto_max_bulk_len) {
++static int checkStringLength(client *c, long long size, long long append) {
++    if (mustObeyClient(c))
++        return C_OK;
++    /* 'uint64_t' cast is there just to prevent undefined behavior on overflow */
++    long long total = (uint64_t)size + append;
++    /* Test configured max-bulk-len represending a limit of the biggest string object,
++     * and also test for overflow. */
++    if (total > server.proto_max_bulk_len || total < size || total < append) {
+         addReplyError(c,"string exceeds maximum allowed size (proto-max-bulk-len)");
+         return C_ERR;
+     }
+@@ -456,7 +462,7 @@ void setrangeCommand(client *c) {
+         }
+ 
+         /* Return when the resulting string exceeds allowed size */
+-        if (checkStringLength(c,offset+sdslen(value)) != C_OK)
++        if (checkStringLength(c,offset,sdslen(value)) != C_OK)
+             return;
+ 
+         o = createObject(OBJ_STRING,sdsnewlen(NULL, offset+sdslen(value)));
+@@ -476,7 +482,7 @@ void setrangeCommand(client *c) {
+         }
+ 
+         /* Return when the resulting string exceeds allowed size */
+-        if (checkStringLength(c,offset+sdslen(value)) != C_OK)
++        if (checkStringLength(c,offset,sdslen(value)) != C_OK)
+             return;
+ 
+         /* Create a copy when the object is shared or encoded. */
+@@ -703,8 +709,7 @@ void appendCommand(client *c) {
+ 
+         /* "append" is an argument, so always an sds */
+         append = c->argv[2];
+-        totlen = stringObjectLen(o)+sdslen(append->ptr);
+-        if (checkStringLength(c,totlen) != C_OK)
++        if (checkStringLength(c,stringObjectLen(o),sdslen(append->ptr)) != C_OK)
+             return;
+ 
+         /* Append the value */
+diff --git a/tests/unit/sort.tcl b/tests/unit/sort.tcl
+index 760c58c..e9f1de0 100644
+--- a/tests/unit/sort.tcl
++++ b/tests/unit/sort.tcl
+@@ -331,4 +331,15 @@ start_server {
+             }
+         } {} {cluster:skip}
+     }
++
++    test {SETRANGE with huge offset} {
++        r lpush L 2 1 0
++        # expecting a different outcome on 32 and 64 bit systems
++        foreach value {9223372036854775807 2147483647} {
++            catch {[r sort_ro L by a limit 2 $value]} res
++            if {![string match "2" $res] && ![string match "*out of range*" $res]} {
++                assert_not_equal $res "expecting an error or 2"
++            }
++        }
++    }
+ }
+diff --git a/tests/unit/type/string.tcl b/tests/unit/type/string.tcl
+index d04bdff..36b349e 100644
+--- a/tests/unit/type/string.tcl
++++ b/tests/unit/type/string.tcl
+@@ -598,4 +598,14 @@ start_server {tags {"string"}} {
+     test {LCS indexes with match len and minimum match len} {
+         dict get [r LCS virus1{t} virus2{t} IDX WITHMATCHLEN MINMATCHLEN 5] matches
+     } {{{1 222} {13 234} 222}}
++
++    test {SETRANGE with huge offset} {
++        foreach value {9223372036854775807 2147483647} {
++            catch {[r setrange K $value A]} res
++            # expecting a different error on 32 and 64 bit systems
++            if {![string match "*string exceeds maximum allowed size*" $res] && ![string match "*out of range*" $res]} {
++                assert_equal $res "expecting an error"
++           }
++        }
++    }
+ }

--- a/recipes-extended/redis/redis/CVE-2022-36021_7.0.4_fix.patch
+++ b/recipes-extended/redis/redis/CVE-2022-36021_7.0.4_fix.patch
@@ -1,0 +1,86 @@
+From f31a8dbf2ed315f14e1e895011079d66930eccc4 Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/redis/redis/commit/dcbfcb916ca1a269b3feef86ee86835294758f84
+CVE: CVE-2022-36021
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ src/util.c              | 27 +++++++++++++++++++++++----
+ tests/unit/keyspace.tcl |  6 ++++++
+ 2 files changed, 29 insertions(+), 4 deletions(-)
+
+diff --git a/src/util.c b/src/util.c
+index 4b534e9..8336312 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -50,8 +50,8 @@
+ #include "config.h"
+ 
+ /* Glob-style pattern matching. */
+-int stringmatchlen(const char *pattern, int patternLen,
+-        const char *string, int stringLen, int nocase)
++static int stringmatchlen_impl(const char *pattern, int patternLen,
++        const char *string, int stringLen, int nocase, int *skipLongerMatches)
+ {
+     while(patternLen && stringLen) {
+         switch(pattern[0]) {
+@@ -63,12 +63,25 @@ int stringmatchlen(const char *pattern, int patternLen,
+             if (patternLen == 1)
+                 return 1; /* match */
+             while(stringLen) {
+-                if (stringmatchlen(pattern+1, patternLen-1,
+-                            string, stringLen, nocase))
++                if (stringmatchlen_impl(pattern+1, patternLen-1,
++                            string, stringLen, nocase, skipLongerMatches))
+                     return 1; /* match */
++                if (*skipLongerMatches)
++                    return 0; /* no match */
+                 string++;
+                 stringLen--;
+             }
++            /* There was no match for the rest of the pattern starting
++             * from anywhere in the rest of the string. If there were
++             * any '*' earlier in the pattern, we can terminate the
++             * search early without trying to match them to longer
++             * substrings. This is because a longer match for the
++             * earlier part of the pattern would require the rest of the
++             * pattern to match starting later in the string, and we
++             * have just determined that there is no match for the rest
++             * of the pattern starting from anywhere in the current
++             * string. */
++            *skipLongerMatches = 1;
+             return 0; /* no match */
+             break;
+         case '?':
+@@ -170,6 +183,12 @@ int stringmatchlen(const char *pattern, int patternLen,
+     return 0;
+ }
+ 
++int stringmatchlen(const char *pattern, int patternLen,
++        const char *string, int stringLen, int nocase) {
++    int skipLongerMatches = 0;
++    return stringmatchlen_impl(pattern,patternLen,string,stringLen,nocase,&skipLongerMatches);
++}
++
+ int stringmatch(const char *pattern, const char *string, int nocase) {
+     return stringmatchlen(pattern,strlen(pattern),string,strlen(string),nocase);
+ }
+diff --git a/tests/unit/keyspace.tcl b/tests/unit/keyspace.tcl
+index f5f9711..437f71f 100644
+--- a/tests/unit/keyspace.tcl
++++ b/tests/unit/keyspace.tcl
+@@ -489,4 +489,10 @@ start_server {tags {"keyspace"}} {
+         r keys *
+         r keys *
+     } {dlskeriewrioeuwqoirueioqwrueoqwrueqw}
++
++    test {Regression for pattern matching long nested loops} {
++        r flushdb
++        r SET aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1
++        r KEYS "a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*b"
++    } {}
+ }

--- a/recipes-extended/redis/redis/CVE-2023-41053_7.0.4_fix.patch
+++ b/recipes-extended/redis/redis/CVE-2023-41053_7.0.4_fix.patch
@@ -1,0 +1,44 @@
+From fe5c2cf40b3ad83ee1ae74357ce440e8e75dc510 Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/redis/redis/commit/9e505e6cd842338424e05883521ca1fb7d0f47f6
+CVE: CVE-2023-41053
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ src/db.c            | 3 ++-
+ tests/unit/sort.tcl | 4 ++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/db.c b/src/db.c
+index f4f37b5..c5ffc58 100644
+--- a/src/db.c
++++ b/src/db.c
+@@ -2180,7 +2180,8 @@ int sortROGetKeys(struct redisCommand *cmd, robj **argv, int argc, getKeysResult
+     keys = getKeysPrepareResult(result, 1);
+     keys[0].pos = 1; /* <sort-key> is always present. */
+     keys[0].flags = CMD_KEY_RO | CMD_KEY_ACCESS;
+-    return 1;
++    result->numkeys = 1;
++    return result->numkeys;
+ }
+ 
+ /* Helper function to extract keys from the SORT command.
+diff --git a/tests/unit/sort.tcl b/tests/unit/sort.tcl
+index a9264ea..760c58c 100644
+--- a/tests/unit/sort.tcl
++++ b/tests/unit/sort.tcl
+@@ -97,6 +97,10 @@ start_server {
+     test "SORT extracts STORE correctly" {
+         r command getkeys sort abc store def
+     } {abc def}
++    
++    test "SORT_RO get keys" {
++        r command getkeys sort_ro abc
++    } {abc}
+ 
+     test "SORT extracts multiple STORE correctly" {
+         r command getkeys sort abc store invalid store stillbad store def

--- a/recipes-extended/redis/redis/CVE-2023-45145_7.0.4_fix.patch
+++ b/recipes-extended/redis/redis/CVE-2023-45145_7.0.4_fix.patch
@@ -1,0 +1,57 @@
+From a56d79fd830068a017a4e28b5c239ba3f983270d Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/redis/redis/commit/03345ddc7faf7af079485f2cbe5d17a1611cbce1
+CVE: CVE-2023-45145
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ src/anet.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/src/anet.c b/src/anet.c
+index 4ea201d..10840fc 100644
+--- a/src/anet.c
++++ b/src/anet.c
+@@ -407,13 +407,16 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
+     return s;
+ }
+ 
+-static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int backlog) {
++static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int backlog, mode_t perm) {
+     if (bind(s,sa,len) == -1) {
+         anetSetError(err, "bind: %s", strerror(errno));
+         close(s);
+         return ANET_ERR;
+     }
+ 
++    if (sa->sa_family == AF_LOCAL && perm)
++        chmod(((struct sockaddr_un *) sa)->sun_path, perm);
++
+     if (listen(s, backlog) == -1) {
+         anetSetError(err, "listen: %s", strerror(errno));
+         close(s);
+@@ -457,7 +460,7 @@ static int _anetTcpServer(char *err, int port, char *bindaddr, int af, int backl
+ 
+         if (af == AF_INET6 && anetV6Only(err,s) == ANET_ERR) goto error;
+         if (anetSetReuseAddr(err,s) == ANET_ERR) goto error;
+-        if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog) == ANET_ERR) s = ANET_ERR;
++        if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog,0) == ANET_ERR) s = ANET_ERR;
+         goto end;
+     }
+     if (p == NULL) {
+@@ -498,10 +501,8 @@ int anetUnixServer(char *err, char *path, mode_t perm, int backlog)
+     memset(&sa,0,sizeof(sa));
+     sa.sun_family = AF_LOCAL;
+     strncpy(sa.sun_path,path,sizeof(sa.sun_path)-1);
+-    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa),backlog) == ANET_ERR)
++    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa),backlog,perm) == ANET_ERR)
+         return ANET_ERR;
+-    if (perm)
+-        chmod(sa.sun_path, perm);
+     return s;
+ }
+ 

--- a/recipes-extended/redis/redis_7.0.4%.bbappend
+++ b/recipes-extended/redis/redis_7.0.4%.bbappend
@@ -5,4 +5,8 @@ SRC_URI:append = " file://CVE-2023-25155_7.0.4_fix.patch \
                    file://CVE-2023-36824_7.0.4_fix.patch \
                    file://CVE-2022-24834_7.0.4_fix.patch \
                    file://CVE-2022-35951_7.0.4_fix.patch \
+                   file://CVE-2023-45145_7.0.4_fix.patch \
+                   file://CVE-2023-41053_7.0.4_fix.patch \
+                   file://CVE-2022-36021_7.0.4_fix.patch \
+                   file://CVE-2022-35977_7.0.4_fix.patch \
                  "

--- a/recipes-graphics/xorg-lib/pixman/CVE-2022-44638_0.40_fix.patch
+++ b/recipes-graphics/xorg-lib/pixman/CVE-2022-44638_0.40_fix.patch
@@ -1,0 +1,27 @@
+From db3933dcffccc9b71332c71493ae4c6f10fea5de Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://gitlab.freedesktop.org/pixman/pixman/-/commit/a1f88e842e0216a5b4df1ab023caebe33c101395
+CVE: CVE-2022-44638
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ pixman/pixman-trap.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pixman/pixman-trap.c b/pixman/pixman-trap.c
+index 91766fd..7560405 100644
+--- a/pixman/pixman-trap.c
++++ b/pixman/pixman-trap.c
+@@ -74,7 +74,7 @@ pixman_sample_floor_y (pixman_fixed_t y,
+ 
+     if (f < Y_FRAC_FIRST (n))
+     {
+-	if (pixman_fixed_to_int (i) == 0x8000)
++	if (pixman_fixed_to_int (i) == 0xffff8000)
+ 	{
+ 	    f = 0; /* saturate */
+ 	}

--- a/recipes-graphics/xorg-lib/pixman_0.40.0.bbappend
+++ b/recipes-graphics/xorg-lib/pixman_0.40.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://CVE-2022-44638_0.40_fix.patch"

--- a/recipes-support/gmp/gmp/CVE-2021-43618_4.2.1_fix.patch
+++ b/recipes-support/gmp/gmp/CVE-2021-43618_4.2.1_fix.patch
@@ -1,0 +1,41 @@
+From f7deca2c3a364f1aaaae37133416ce97bf3d551b Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Date: Wed, 8 Jan 2025 16:18:13 +0000
+Subject: [PATCH]
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://gmplib.org/repo/gmp-6.2/rev/561a9c25298e
+CVE : CVE-2021-43618
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ mpz/inp_raw.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/mpz/inp_raw.c b/mpz/inp_raw.c
+index 735dcf3..5ab96bc 100644
+--- a/mpz/inp_raw.c
++++ b/mpz/inp_raw.c
+@@ -23,7 +23,7 @@ MA 02110-1301, USA. */
+ #include "gmp.h"
+ #include "gmp-impl.h"
+ 
+-
++typedef unsigned long int        mp_bitcnt_t;
+ /* NTOH_LIMB_FETCH fetches a limb which is in network byte order (ie. big
+    endian) and produces a normal host byte order result. */
+ 
+@@ -83,8 +83,11 @@ mpz_inp_raw (mpz_ptr x, FILE *fp)
+ 
+   abs_csize = ABS (csize);
+ 
++  if (UNLIKELY (abs_csize > ~(mp_bitcnt_t) 0 / 8))
++      return 0; /* Bit size overflows */
++
+   /* round up to a multiple of limbs */
+-  abs_xsize = (abs_csize*8 + GMP_NUMB_BITS-1) / GMP_NUMB_BITS;
++  abs_xsize = BITS_TO_LIMBS ((mp_bitcnt_t) abs_csize * 8);
+ 
+   if (abs_xsize != 0)
+     {
+

--- a/recipes-support/gmp/gmp_4.2.1.bbappend
+++ b/recipes-support/gmp/gmp_4.2.1.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://CVE-2021-43618_4.2.1_fix.patch"

--- a/recipes-support/libarchive/libarchive/CVE-2024-48957_fix.patch
+++ b/recipes-support/libarchive/libarchive/CVE-2024-48957_fix.patch
@@ -1,0 +1,32 @@
+From ae382ed94d2393aea82ae803bfa1a4ca2e19ee4b Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH]
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/libarchive/libarchive/commit/3006bc5d02ad3ae3c4f9274f60c1f9d2d834734b
+CVE: CVE-2024-48957
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ libarchive/archive_read_support_format_rar.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index fae7d9b8..dca0ab80 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -3708,6 +3708,13 @@ execute_filter_audio(struct rar_filter *filter, struct rar_virtual_machine *vm)
+     memset(&state, 0, sizeof(state));
+     for (j = i; j < length; j += numchannels)
+     {
++      /*
++       * The src block should not overlap with the dst block.
++       * If so it would be better to consider this archive is broken.
++       */
++      if (src >= dst)
++        return 0;
++
+       int8_t delta = (int8_t)*src++;
+       uint8_t predbyte, byte;
+       int prederror;

--- a/recipes-support/libarchive/libarchive/CVE-2024-48958_fix.patch
+++ b/recipes-support/libarchive/libarchive/CVE-2024-48958_fix.patch
@@ -1,0 +1,34 @@
+From 67cc639c6f3efa8c18cfc4f7253b99513839a6fd Mon Sep 17 00:00:00 2001
+From: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+Subject: [PATCH] 
+Date: Jan 7, 2025
+From: Srihariraghava_konduritirumala@comcast.com
+Source: upstream
+        https://github.com/libarchive/libarchive/commit/a1cb648d52f5b6d3f31184d9b6a7cbca628459b7
+CVE: CVE-2024-48958
+
+Signed-off-by: skondu363 <Srihariraghava_konduritirumala@comcast.com>
+---
+ libarchive/archive_read_support_format_rar.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libarchive/archive_read_support_format_rar.c b/libarchive/archive_read_support_format_rar.c
+index f9cbe2a8..fae7d9b8 100644
+--- a/libarchive/archive_read_support_format_rar.c
++++ b/libarchive/archive_read_support_format_rar.c
+@@ -3598,7 +3598,15 @@ execute_filter_delta(struct rar_filter *filter, struct rar_virtual_machine *vm)
+   {
+     uint8_t lastbyte = 0;
+     for (idx = i; idx < length; idx += numchannels)
++    {
++      /*
++       * The src block should not overlap with the dst block.
++       * If so it would be better to consider this archive is broken.
++       */
++      if (src >= dst)
++        return 0;
+       lastbyte = dst[idx] = lastbyte - *src++;
++    }
+   }
+
+   filter->filteredblockaddress = length;

--- a/recipes-support/libarchive/libarchive_3.6.1.bbappend
+++ b/recipes-support/libarchive/libarchive_3.6.1.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS:prepend:="${THISDIR}/${PN}:"
 
-SRC_URI:append = " file://CVE-2022-36227_fix.patch "
+SRC_URI:append = " file://CVE-2022-36227_fix.patch \
+                   file://CVE-2024-48957_fix.patch \
+                   file://CVE-2024-48958_fix.patch \
+                 "


### PR DESCRIPTION
RDK-55486:Patching CVE for pixman package
Reason for change: Addressing CVE #https://github.com/advisories/GHSA-jw33-72hm-ggg2 of pixman package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: I367a98b052e056d1125be99f00623b365390f296

RDK-55483:Patching CVE for redis package

Reason for change: Addressing multiple CVEs of redis package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: I3c7f4dbfc2c08f50075e856eaa802a59128f010f

RDK-55484,RDKB-58348:Patching CVE for libarchive package

Reason for change: Addressing multiple CVEs of libarchive package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: Ia449ec71b9f47f4d941c12ecf84c26a90179efba

RDK-55485,RDKB-58356:Patching CVE for libpam package

Reason for change: Addressing multiple CVEs of libpam package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: Ia9201de9a7eba139f77072d8c107633299aaa334

RDKB-58357,RDK-55334:Patching CVE for bind package

Reason for change: Addressing multiple CVEs of bind package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: I4872626b45ce3fc91840112a6803b396c158e4e8

RDKB-58358,RDK-55490:Patching CVE for gmp package

Reason for change: Addressing #https://github.com/advisories/GHSA-mfg4-w44m-wr4g of gmp package Test Procedure: Build and verify if CVEs are patched and functionality of the components remain unaffected.
Risks: None
Priority: P2

Change-Id: I188d86b1df667e55d72c55028355f353be90ab51