### PR TITLE
RDKE-2035: Remove networkmanager-wait-online.service

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -217,6 +217,8 @@ FILES:${PN}:remove = "${sysconfdir}/resolv.dnsmasq"
 FILES:${PN}:remove = "${sysconfdir}/resolv.conf"
 FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.conf"
 FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.dnsmasq"
+FLIES:${PN}-daemon:remove = "${systemd_system_unitdir}/NetworkManager-wait-online.service"
+
 #{nonarch_libdir}/NetworkManager/system-connections
 RDEPENDS:${PN}-daemon += "\
     ${@bb.utils.contains('PACKAGECONFIG', 'ifupdown', 'bash', '', d)} \
@@ -230,6 +232,8 @@ SYSTEMD_SERVICE:${PN}-daemon = "\
     NetworkManager.service \
     NetworkManager-dispatcher.service \
 "
+SYSTEMD_SERVICE:${PN}-daemon:remove = "NetworkManager-wait-online.service"
+
 RCONFLICTS:${PN}-daemon += "connman"
 ALTERNATIVE_PRIORITY = "100"
 ALTERNATIVE:${PN}-daemon = "${@bb.utils.contains('PACKAGECONFIG','man-resolv-conf','resolv-conf','',d)}"


### PR DESCRIPTION
Reason for change: Remove wait-online service as it is not required.
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)