### PR TITLE
RDKOSS-171: Include lsof utility

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -593,6 +593,9 @@ PACKAGE_ARCH:pn-log4c = "${OSS_LAYER_ARCH}"
 PR:pn-logrotate = "r1"
 PACKAGE_ARCH:pn-logrotate = "${OSS_LAYER_ARCH}"
 
+PR:pn-lsof = "r0"
+PACKAGE_ARCH:pn-lsof = "${OSS_LAYER_ARCH}"
+
 PR:pn-lttng-ust = "r0"
 PACKAGE_ARCH:pn-lttng-ust = "${OSS_LAYER_ARCH}"
 

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -114,6 +114,7 @@ RDEPENDS:${PN} = "\
      libxcrypt \
      libxml2 \
      libxslt \
+     lsof \
      lttng-ust \
      lz4 \
      lzo \


### PR DESCRIPTION
Reason for change: The lsof utility is need by the diskcheck script in sysint middleware module