### PR TITLE
RDKEMW-2035 [RDKE][Xione-UK]- Review Networkmanager-wait service start/initialize for RDKE 5 

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -217,6 +217,7 @@ FILES:${PN}:remove = "${sysconfdir}/resolv.dnsmasq"
 FILES:${PN}:remove = "${sysconfdir}/resolv.conf"
 FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.conf"
 FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.dnsmasq"
+FLIES:${PN}-daemon:remove = "${systemd_system_unitdir}/NetworkManager-wait-online.service"
 #{nonarch_libdir}/NetworkManager/system-connections
 RDEPENDS:${PN}-daemon += "\
     ${@bb.utils.contains('PACKAGECONFIG', 'ifupdown', 'bash', '', d)} \
@@ -230,6 +231,7 @@ SYSTEMD_SERVICE:${PN}-daemon = "\
     NetworkManager.service \
     NetworkManager-dispatcher.service \
 "
+SYSTEMD_SERVICE:${PN}-daemon:remove = "NetworkManager-wait-online.service"
 RCONFLICTS:${PN}-daemon += "connman"
 ALTERNATIVE_PRIORITY = "100"
 ALTERNATIVE:${PN}-daemon = "${@bb.utils.contains('PACKAGECONFIG','man-resolv-conf','resolv-conf','',d)}"


### PR DESCRIPTION
RDKEMW-2035 [RDKE][Xione-UK]- Review Networkmanager-wait service start/initialize for RDKE 
Reason for change: Removing the network manager wait service 
Test Procedure: Verified that basic internet connectivity/SSH/AV playback is fine. 
Risks: None
Priority: P1
Signed-off-by: Vismal S Kumar <VismalSasi_Kumar@comcast.com>