### PR TITLE
RDK-56463: libwpe v1.16 upgrade

### DIFF
--- a/recipes-extended/libwpe/libwpe_1.16.2.bb
+++ b/recipes-extended/libwpe/libwpe_1.16.2.bb
@@ -11,7 +11,8 @@ inherit cmake features_check pkgconfig
 REQUIRED_DISTRO_FEATURES = "opengl"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz"
-SRC_URI[sha256sum] = "c073305bbac5f4402cc1c8a4753bfa3d63a408901f86182051eaa5a75dd89c00"
+
+SRC_URI[sha256sum] = "960bdd11c3f2cf5bd91569603ed6d2aa42fd4000ed7cac930a804eac367888d7"
 
 # This is a tweak of upstream-version-is-even needed because
 # ipstream directory contains tarballs for other components as well.


### PR DESCRIPTION
Reason for change: Upgrade libwpe to 1.16.2
Test Procedure: Smoke webapps testing
Risks: Low
Priority: P1