### PR TITLE
RDK-56684: Updating Westeros to latest 1.01.58

### DIFF
--- a/recipes-graphics/westeros/westeros.inc
+++ b/recipes-graphics/westeros/westeros.inc
@@ -6,8 +6,8 @@ SRC_URI = "${WESTEROS_URI}"
 SRCREV = "${WESTEROS_SRCREV}"
 
 WESTEROS_URI ?= "${CMF_GIT_ROOT}/components/opensource/westeros;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};name=westeros"
-# Tip of westeros master as of Aug 14, 2023
-WESTEROS_SRCREV ?= "7a360aeba315725003e86f339bb06e629aa7353e"
+# Tip of westeros master as of Feb 26 2025 Westeros-1.01.58
+WESTEROS_SRCREV ?= "3472e863adf4909504f192662a6f28bde08658ce"
 
 LICENSE_LOCATION ?= "${S}/LICENSE"
 LIC_FILES_CHKSUM = "file://${LICENSE_LOCATION};md5=8fb65319802b0c15fc9e0835350ffa02"


### PR DESCRIPTION
Reason for change: Update RDKE version of Westeros to latest on stable2  i.e https://code.rdkcentral.com/r/plugins/gitiles/components/opensource/westeros/+/3472e863adf4909504f192662a6f28bde08658ce

Change-Id: Ie7040f99809ed5552109f482594aff31d81807e2