### PR TITLE
RDKOSS-304 : Change PV to 4.6.3 for hotfix release

### DIFF
--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -6,7 +6,7 @@ PACKAGE_ARCH = "${OSS_LAYER_ARCH}"
 
 inherit packagegroup
 
-PV = "4.6.0"
+PV = "4.6.3"
 PR = "r0"
 
 # poky components


### PR DESCRIPTION
Change PV to 4.6.3 in meta-rdk-oss-reference for hotfix release