### PR TITLE
RDKEMW-4694: NetworkManager service is in failed state

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -656,7 +656,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r0"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r4"
+PR:pn-networkmanager = "r5"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM-wpa-service.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM-wpa-service.patch
@@ -16,13 +16,12 @@ Index: NetworkManager-1.43.7/data/NetworkManager.service.in
  BindsTo=dbus.service
 
  [Service]
-@@ -11,6 +11,8 @@ Type=dbus
+@@ -11,6 +11,7 @@ Type=dbus
  BusName=org.freedesktop.NetworkManager
  ExecReload=/usr/bin/busctl call org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Reload u 0
  #ExecReload=/bin/kill -HUP $MAINPID
 +ExecStartPre= /bin/sh -c 'if [ ! -d /opt/NetworkManager/system-connections ];then mkdir -p /opt/NetworkManager/system-connections; fi'
  ExecStart=@sbindir@/NetworkManager --no-daemon
-+ExecStartPost=/bin/sh /lib/rdk/NM_restartConn.sh
  Restart=on-failure
  # NM doesn't want systemd to kill its children for it
 Index: NetworkManager-1.43.7/tools/meson-post-install.sh


### PR DESCRIPTION
Reason for change: Remove unused scripts in NetworkManager
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)