### PR TITLE
RDK-57139:  Enabling segmented global profile in RDKE (#77)

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -801,7 +801,7 @@ PACKAGE_ARCH:pn-sysfsutils = "${OSS_LAYER_ARCH}"
 PR:pn-syslog-ng = "r2"
 PACKAGE_ARCH:pn-syslog-ng = "${OSS_LAYER_ARCH}"
 
-PR:pn-systemd = "r10"
+PR:pn-systemd = "r11"
 PACKAGE_ARCH:pn-systemd = "${OSS_LAYER_ARCH}"
 
 PR:pn-systemd-serialgetty = "r5"

--- a/recipes-core/systemd/systemd_230.bbappend
+++ b/recipes-core/systemd/systemd_230.bbappend
@@ -7,6 +7,10 @@ PACKAGECONFIG:remove = " resolved nss-resolve "
 
 PACKAGECONFIG:remove:libc-uclibc = "sysusers machined"
 
+DEPENDS += " ${@bb.utils.contains("DISTRO_FEATURES", "apparmor", " apparmor", "" ,d)}"
+PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'apparmor', 'apparmor', '', d)}"
+PACKAGECONFIG[apparmor] = "--enable-apparmor, --disable-apparmor"
+
 #Remove volatile bind dependency as it is not an oss delivered component
 RDEPENDS:${PN}:remove = "volatile-binds"
 


### PR DESCRIPTION
Reason for change: Enable apparmor for systemd