### PR TITLE
RDKOSS-306:Bring in required grpc apis

### DIFF
--- a/recipes-devtools/grpc/grpc_%.bbappend
+++ b/recipes-devtools/grpc/grpc_%.bbappend
@@ -3,7 +3,4 @@ FILES:${PN}-extras =  "\
                         ${libdir}/libgrpc++_alts.so* \
                         ${libdir}/libgrpc++_error_details.so* \
                         ${libdir}/libgrpc++_reflection.so* \
-                        ${libdir}/libgrpc++_unsecure.so* \
-                        ${libdir}/libgrpc_unsecure.so* \
-                        ${libdir}/libgrpcpp_channelz.so* \
 "


### PR DESCRIPTION
Reason for change: rialto uses channelz and unsecure apis, hence bringing back those libraries to rootfs and it has dependency.