### PR TITLE
RDK-56652:Enforce SSH connection to lab/test devices

### DIFF
--- a/recipes-core/dropbear/dropbear/authkeys.patch
+++ b/recipes-core/dropbear/dropbear/authkeys.patch
@@ -1,0 +1,114 @@
+From b6998b005dc6831b68365a9219cf21e5fb997ff1 Mon Sep 17 00:00:00 2001
+From: nm296 <nareshkumar_m@comcast.com>
+Date: Thu, 29 May 2025 07:03:46 +0000
+Subject: [PATCH] From: nm296 <nareshkumar_m@comcast.com> Date: Mon, 7 Apr 2025
+ 09:38:51 +0000 Subject: [PATCH] Source: Local Subject: Patching dropbear to
+ accept custom authorized_keys file
+
+Signed-off-by: nm296 <nareshkumar_m@comcast.com>
+---
+ runopts.h        |  1 +
+ svr-authpubkey.c | 21 ++++++++++++++++++++-
+ svr-runopts.c    |  5 +++++
+ 3 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/runopts.h b/runopts.h
+index 01201d2..ce4d24e 100644
+--- a/runopts.h
++++ b/runopts.h
+@@ -69,6 +69,7 @@ void load_all_hostkeys(void);
+ typedef struct svr_runopts {
+ 
+ 	char * bannerfile;
++	char * auth_keys_file;
+ 
+ 	int forkbg;
+ 
+diff --git a/svr-authpubkey.c b/svr-authpubkey.c
+index abfc80b..b9a7e56 100644
+--- a/svr-authpubkey.c
++++ b/svr-authpubkey.c
+@@ -64,6 +64,7 @@
+ #include "ssh.h"
+ #include "packet.h"
+ #include "algo.h"
++#include "runopts.h"
+ 
+ #if DROPBEAR_SVR_PUBKEY_AUTH
+ 
+@@ -393,9 +394,17 @@ static int checkpubkey(const char* keyalgo, unsigned int keyalgolen,
+ 	len = strlen(ses.authstate.pw_dir);
+ 	/* allocate max required pathname storage,
+ 	 * = path + "/.ssh/authorized_keys" + '\0' = pathlen + 22 */
++	if (svr_opts.auth_keys_file) {
++	    len += strlen(svr_opts.auth_keys_file);
++	    filename = m_malloc(len + 7);
++	    snprintf(filename, len + 7, "%s/.ssh/%s",
++			    ses.authstate.pw_dir,
++			    svr_opts.auth_keys_file);
++	}else {
+ 	filename = m_malloc(len + 22);
+ 	snprintf(filename, len + 22, "%s/.ssh/authorized_keys", 
+ 				ses.authstate.pw_dir);
++	}
+ 
+ #if DROPBEAR_SVR_MULTIUSER
+ 	/* open the file as the authenticating user. */
+@@ -478,8 +487,13 @@ static int checkpubkeyperms() {
+ 
+ 	/* allocate max required pathname storage,
+ 	 * = path + "/.ssh/authorized_keys" + '\0' = pathlen + 22 */
++	if (svr_opts.auth_keys_file) {
++            len += strlen(svr_opts.auth_keys_file)+7;
++	    filename = m_malloc(len);
++	} else {
+ 	len += 22;
+ 	filename = m_malloc(len);
++	}
+ 	strlcpy(filename, ses.authstate.pw_dir, len);
+ 
+ 	/* check ~ */
+@@ -494,7 +508,12 @@ static int checkpubkeyperms() {
+ 	}
+ 
+ 	/* now check ~/.ssh/authorized_keys */
+-	strlcat(filename, "/authorized_keys", len);
++        if (svr_opts.auth_keys_file) {
++	    strlcat(filename, "/" , len);
++            strlcat(filename , svr_opts.auth_keys_file ,len);
++	} else {
++        strlcat(filename, "/authorized_keys", len);
++	}
+ 	if (checkfileperm(filename) != DROPBEAR_SUCCESS) {
+ 		goto out;
+ 	}
+diff --git a/svr-runopts.c b/svr-runopts.c
+index 2c905dd..0626baa 100644
+--- a/svr-runopts.c
++++ b/svr-runopts.c
+@@ -106,6 +106,7 @@ static void printhelp(const char * progname) {
+                                         "-A <authplugin>[,<options>]\n"
+                                         "               Enable external public key auth through <authplugin>\n"
+ #endif
++					"-f <file> use file as authorized_key file \n"
+ 					"-V    Version\n"
+ #if DEBUG_TRACE
+ 					"-v		verbose (compiled with DEBUG_TRACE)\n"
+@@ -146,6 +147,7 @@ void svr_getopts(int argc, char ** argv) {
+ 
+ 	/* see printhelp() for options */
+ 	svr_opts.bannerfile = NULL;
++	svr_opts.auth_keys_file = NULL;
+ 	svr_opts.banner = NULL;
+ 	svr_opts.forced_command = NULL;
+ 	svr_opts.forkbg = 1;
+@@ -208,6 +210,9 @@ void svr_getopts(int argc, char ** argv) {
+ 				case 'c':
+ 					next = &svr_opts.forced_command;
+ 					break;
++		                case 'f':
++					next = &svr_opts.auth_keys_file;
++					break;
+ 				case 'd':
+ 				case 'r':
+ 					next = &keyfile;

--- a/recipes-core/dropbear/dropbear_2020.%.bbappend
+++ b/recipes-core/dropbear/dropbear_2020.%.bbappend
@@ -7,5 +7,5 @@ SRC_URI:append = " file://dropbear_2019-verbose.patch \
                    file://dropbear_2019-revsshipv6.patch \
                    file://dropbear_2019-Fixed-Race-Conditions-Observed-when-using-port-forwa.patch \
 "
-
 SRC_URI:append = " file://dropbear_performance__kirkstone_issue.patch "
+SRC_URI:append = "file://authkeys.patch"


### PR DESCRIPTION
Reason for change: Add deviceType RFC check before launching dropbear
Test Procedure: Flash the build , ssh and verify
Risks: High
Priority: P1