### PR TITLE
Feature/rdke 850 (#122)

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -179,6 +179,9 @@ PACKAGE_ARCH:pn-e2fsprogs = "${OSS_LAYER_ARCH}"
 PR:pn-ebtables = "r4"
 PACKAGE_ARCH:pn-ebtables = "${OSS_LAYER_ARCH}"
 
+PR:pn-ethtool = "r0"
+PACKAGE_ARCH:pn-ethtool = "${OSS_LAYER_ARCH}"
+
 PR:pn-elfutils = "r0"
 PACKAGE_ARCH:pn-elfutils = "${OSS_LAYER_ARCH}"
 
@@ -427,6 +430,9 @@ PACKAGE_ARCH:pn-libmicrohttpd = "${OSS_LAYER_ARCH}"
 
 PR:pn-libmng = "r0"
 PACKAGE_ARCH:pn-libmng = "${OSS_LAYER_ARCH}"
+
+PR:pn-libmnl = "r0"
+PACKAGE_ARCH:pn-libmnl = "${OSS_LAYER_ARCH}"
 
 PR:pn-libndp = "r0"
 PACKAGE_ARCH:pn-libndp = "${OSS_LAYER_ARCH}"

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -179,6 +179,7 @@ RDEPENDS:${PN} += "\
      dibbler-client \
      directfb \
      ebtables \
+     ethtool \
      evtest \
      gflags \
      googletest \
@@ -192,6 +193,7 @@ RDEPENDS:${PN} += "\
      libev \
      libmicrohttpd \
      libmng \
+     libmnl \
      liboauth \
      libol \
      libomxil \


### PR DESCRIPTION
* RDKE-850: Include ethtool and libmnl

Reason for the change: Include  ethtool and libmnl needed for BCM devices into oss release

* Update package_revisions_oss.inc

* Update package_revisions_oss.inc

* Update package_revisions_oss.inc