### PR TITLE
RDK-57964 : Improve NTP Analytics

### DIFF
--- a/recipes-support/dnsmasq/dnsmasq/dnsmasq.service
+++ b/recipes-support/dnsmasq/dnsmasq/dnsmasq.service
@@ -7,6 +7,7 @@ Type=forking
 PIDFile=/run/dnsmasq.pid
 ExecStartPre=-/bin/mkdir -p /var/lib/misc
 ExecStart=/bin/busybox sh -c /lib/rdk/dnsmasqLauncher.sh
+ExecStartPost=/bin/sh -c '[ -f /lib/rdk/logMilestone.sh ] && /bin/sh /lib/rdk/logMilestone.sh "DNSMASQ_STARTED"'
 ExecReload=/bin/kill -USR1 $(/bin/cat /run/dnsmasq.pid)
 TimeoutStartSec=5s
 Restart=always


### PR DESCRIPTION
Reason for change: To Capture the time when the dnsmasq is started
Test Procedure: Configure telemetry profile and check if markers are hit 
Risks: None
Signed-off-by:Sindhuja <Sindhuja_Muthukrishnan@comcast.com>