### PR TITLE
RDKE-855: Include wayland-default-egl

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -864,6 +864,9 @@ PACKAGE_ARCH:pn-vmtouch = "${OSS_LAYER_ARCH}"
 PR:pn-wayland = "r0"
 PACKAGE_ARCH:pn-wayland = "${OSS_LAYER_ARCH}"
 
+PR:pn-wayland-default-egl = "r0"
+PACKAGE_ARCH:pn-wayland-default-egl = "${OSS_LAYER_ARCH}"
+
 PR:pn-wayland-protocols = "r1"
 PACKAGE_ARCH:pn-wayland-protocols = "${OSS_LAYER_ARCH}"
 

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -323,6 +323,7 @@ RDEPENDS:${PN} += "\
      trower-base64 \
      vmtouch \
      volatile-binds \
+     wayland-default-egl \
      westeros \
      westeros-simplebuffer \
      westeros-simpleshell \

--- a/recipes-graphics/wayland/files/CMakeLists.txt
+++ b/recipes-graphics/wayland/files/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(wayland-egl VERSION 1.18.0 DESCRIPTION "Frontend wayland-egl library")
+
+include(GNUInstallDirs)
+
+add_library(${PROJECT_NAME} SHARED wayland-egl.c)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION 1.0.0 SOVERSION 1)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+set(prefix "/usr")
+set(exec_prefix "\${prefix}")
+set(libdir "\${exec_prefix}/lib")
+set(includedir "\${prefix}/include")
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/wayland-egl.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/wayland-egl.pc
+    @ONLY)
+
+# Install the pkg-config file
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wayland-egl.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/recipes-graphics/wayland/files/wayland-egl.pc.in
+++ b/recipes-graphics/wayland/files/wayland-egl.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: wayland-egl
+Description: Frontend wayland-egl library
+Version: 18.1.0
+Requires: wayland-client
+Libs: -L${libdir} -lwayland-egl
+Cflags: -I${includedir}

--- a/recipes-graphics/wayland/wayland-default-egl_1.20.0.bb
+++ b/recipes-graphics/wayland/wayland-default-egl_1.20.0.bb
@@ -1,6 +1,7 @@
-# This recipe's intended to provide only the wayland-egl.so and related pkgconfig
-# due to the non-standard wayland package delivery from OSS layer.
-# Refer: ./common/meta-rdk-oss-reference/recipes-graphics/wayland/wayland_%.bbappend
+
+# Provides libwayland-egl.so and related pkgconfig for legacy compatibility
+# Note: This library was removed from Wayland as it's now typically provided by SoC vendors through platform-specific implementations.
+# See related changes: meta-rdk-oss-reference/recipes-graphics/wayland/wayland_%.bbappend
 
 HOMEPAGE = "http://wayland.freedesktop.org"
 LICENSE = "MIT"

--- a/recipes-graphics/wayland/wayland-default-egl_1.20.0.bb
+++ b/recipes-graphics/wayland/wayland-default-egl_1.20.0.bb
@@ -1,0 +1,32 @@
+# This recipe's intended to provide only the wayland-egl.so and related pkgconfig
+# due to the non-standard wayland package delivery from OSS layer.
+# Refer: ./common/meta-rdk-oss-reference/recipes-graphics/wayland/wayland_%.bbappend
+
+HOMEPAGE = "http://wayland.freedesktop.org"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://../COPYING;md5=b31d8f53b6aaf2b4985d7dd7810a70d1 \
+                    file://../src/wayland-server.c;endline=24;md5=b8e046164a766bb1ede8ba38e9dcd7ce"
+
+DEPENDS = "wayland"
+RDEPENDS:${PN} = "wayland"
+
+SRC_URI = "https://wayland.freedesktop.org/releases/wayland-${PV}.tar.xz \
+    file://CMakeLists.txt \
+    file://wayland-egl.pc.in \
+    "
+SRC_URI[sha256sum] = "b8a034154c7059772e0fdbd27dbfcda6c732df29cae56a82274f6ec5d7cd8725"
+
+UPSTREAM_CHECK_URI = "https://wayland.freedesktop.org/releases.html"
+
+S = "${WORKDIR}/wayland-${PV}/egl"
+
+PV ?= "1.20.0"
+PR ?= "r0"
+
+inherit cmake pkgconfig
+
+do_configure:prepend() {
+    cp ${WORKDIR}/CMakeLists.txt ${S}
+    cp ${WORKDIR}/wayland-egl.pc.in ${S}
+}
+


### PR DESCRIPTION
Reason for the change: The libwayland-egl.so has been removed from the Wayland module in OSS, with the assumption that the SoC vendor will provide an equivalent library as part of their platform-specific implementation.  the virtual/egl vendor module bundles libwayland-egl.so, effectively resolving dependencies for other layer modules that rely on libwayland-egl.so.

However, it has been found that some SoC platforms still rely on the libwayland-egl.so library being provided by the Wayland module. Including this library back into the Wayland module would break the build for other SoC platforms that have already providing this lib.

To address this issue, The wayland-default-egl recipe added to the OSS layer, will now provide the default libwayland-egl.so library which can be used on demand, until all platforms have transitioned to the new OSS consumption method, which supports platform specific OSS customization.