### PR TITLE
RDKTV-37484: Add libraries required for iptables service

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -302,7 +302,7 @@ PACKAGE_ARCH:pn-initscripts = "${OSS_LAYER_ARCH}"
 PR:pn-iperf3 = "r0"
 PACKAGE_ARCH:pn-iperf3 = "${OSS_LAYER_ARCH}"
 
-PR:pn-iptables = "r1"
+PR:pn-iptables = "r2"
 PACKAGE_ARCH:pn-iptables = "${OSS_LAYER_ARCH}"
 
 PR:pn-iso-codes = "r0"


### PR DESCRIPTION
Reason for change: Update the util-linux package revision