### PR TITLE
RDKEMW-6391: Remove NetworkManager-wait-online.service

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -656,7 +656,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r0"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r5"
+PR:pn-networkmanager = "r6"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM-wpa-service.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM-wpa-service.patch
@@ -24,6 +24,12 @@ Index: NetworkManager-1.43.7/data/NetworkManager.service.in
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
  # NM doesn't want systemd to kill its children for it
+@@ -37,4 +38,4 @@ Also=NetworkManager-dispatcher.service
+ # is enabled. NetworkManager-wait-online.service has
+ # WantedBy=network-online.target, so enabling it only has an effect if
+ # network-online.target itself is enabled or pulled in by some other unit.
+-Also=NetworkManager-wait-online.service
++#Also=NetworkManager-wait-online.service
 Index: NetworkManager-1.43.7/tools/meson-post-install.sh
 ===================================================================
 --- NetworkManager-1.43.7.orig/tools/meson-post-install.sh

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -213,9 +213,9 @@ FILES:${PN}-daemon += " \
 "
 FILES:${PN}:remove = "${sysconfdir}/resolv.dnsmasq"
 FILES:${PN}:remove = "${sysconfdir}/resolv.conf"
-FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.conf"
-FLIES:${PN}-daemon:remove = "${sysconfdir}/resolv.dnsmasq"
-FLIES:${PN}-daemon:remove = "${systemd_system_unitdir}/NetworkManager-wait-online.service"
+FILES:${PN}-daemon:remove = "${sysconfdir}/resolv.conf"
+FILES:${PN}-daemon:remove = "${sysconfdir}/resolv.dnsmasq"
+FILES:${PN}-daemon:remove = "${systemd_system_unitdir}/NetworkManager-wait-online.service"
 #{nonarch_libdir}/NetworkManager/system-connections
 RDEPENDS:${PN}-daemon += "\
     ${@bb.utils.contains('PACKAGECONFIG', 'ifupdown', 'bash', '', d)} \
@@ -263,7 +263,7 @@ do_install:append() {
     fi
     
     ln -sf /opt/NetworkManager/system-connections ${D}${sysconfdir}/NetworkManager/
-
+    rm -f ${D}${systemd_system_unitdir}/NetworkManager-wait-online.service
     # Enable iwd if compiled
     if ${@bb.utils.contains('PACKAGECONFIG','iwd','true','false',d)}; then
         install -Dm 0644 ${UNPACKDIR}/enable-iwd.conf ${D}${nonarch_libdir}/NetworkManager/conf.d/enable-iwd.conf


### PR DESCRIPTION
Reason for change: Service is not required for device bootup. Removing will improve bootup time by freeing up any dependencies. 
Test Procedure: Build RDKE image and check NM wait online service
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)