### PR TITLE
RDKOSS-414: Fix NetworkManager process crash during reboot

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -662,7 +662,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r0"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r7"
+PR:pn-networkmanager = "r8"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM_Dispatcher.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM_Dispatcher.patch
@@ -1,8 +1,8 @@
-Date: Jun 12 2024
-From: anaras440_comcast <aravindan_narasimhapuramchakravarthy@comcast.com>
+Date: Jul 24 2025
+From: Aravindan NC <nc.aravindan@gmail.com>
 Subject: Add NetworkManager component in RDKE
 Source: COMCAST
-Signed-off-by: anaras440_comcast <aravindan_narasimhapuramchakravarthy@comcast.com>
+Signed-off-by: Aravindan NC <nc.aravindan@gmail.com>
 Index: NetworkManager-1.43.7/data/NetworkManager-dispatcher.service.in
 ===================================================================
 --- NetworkManager-1.43.7.orig/data/NetworkManager-dispatcher.service.in

--- a/recipes-connectivity/networkmanager/networkmanager/NoAssert_Handler.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NoAssert_Handler.patch
@@ -1,0 +1,29 @@
+Date: Jul 24 2025
+From: Aravindan NC <nc.aravindan@gmail.com>
+Subject: Bugfix for NetworkManager component in RDKE
+Source: COMCAST
+Signed-off-by: Aravindan NC <nc.aravindan@gmail.com>
+Index: NetworkManager-1.43.7/src/core/nm-policy.c
+===================================================================
+--- NetworkManager-1.43.7/src/core/nm-policy.c	2023-05-03 14:04:12.000000000 +0000
++++ NetworkManager-1.43.7/src/core/nm-policy.c	2025-07-24 14:49:56.795960853 +0000
+@@ -1662,14 +1662,17 @@
+ 
+     g_return_if_fail(NM_IS_POLICY(self));
+     g_return_if_fail(NM_IS_DEVICE(device));
+-    nm_assert(g_signal_handler_find(device,
++    if(g_signal_handler_find(device,
+                                     G_SIGNAL_MATCH_DATA,
+                                     0,
+                                     0,
+                                     NULL,
+                                     NULL,
+                                     NM_POLICY_GET_PRIVATE(self))
+-              != 0);
++              == 0) {
++        _LOGE(LOGD_DEVICE, "Policy: signal handler not found; skipping auto-activate scheduling.");
++	return;
++    }
+ 
+     if (!c_list_is_empty(&device->policy_auto_activate_lst)) {
+         /* already queued. Return. */

--- a/recipes-connectivity/networkmanager/networkmanager/readline_NM.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/readline_NM.patch
@@ -1,8 +1,8 @@
-Date: Jun 12 2024
-From: anaras440_comcast <aravindan_narasimhapuramchakravarthy@comcast.com>
+Date: Jul 24 2025
+From: Aravindan NC <nc.aravindan@gmail.com>
 Subject: Add NetworkManager component in RDKE
 Source: COMCAST
-Signed-off-by: anaras440_comcast <aravindan_narasimhapuramchakravarthy@comcast.com>
+Signed-off-by: Aravindan NC <nc.aravindan@gmail.com>
 Index: NetworkManager-1.43.7/src/nmcli/common.c
 ===================================================================
 --- NetworkManager-1.43.7.orig/src/nmcli/common.c


### PR DESCRIPTION
Reason for change: Use condition check and error logs instead of assert.
There are timing issues during shutdown where handler may not exist but assert still checks for it.
Test Procedure: Check for NetworkManager crash during reboot
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)