### PR TITLE
RDKOSS-420: Use tune profile to determine OSS package arch

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -18,7 +18,6 @@ def get_oss_arch(d):
     return arch
 
 LAYER_EXTENSION ?= ""
-OSS_MACHINE = "${@get_oss_machine(d)}"
 OSS_LAYER_ARCH = "${@get_oss_arch(d)}${LAYER_EXTENSION}"
 PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
 

--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -1,3 +1,28 @@
+def get_oss_machine(d):
+    arch = ""
+    default_tune = d.getVar('DEFAULTTUNE')
+
+    # need to fix: Workaround to check for 64bit machine with multilib configuration
+    multilib_support = d.getVar('MULTILIBS') or ""
+    if multilib_support:
+        arch = "rdk-arm64"
+    elif "armv7athf-neon" in default_tune:
+        arch = "rdk-arm7a"
+    else:
+        arch = "rdk-arm7ve"
+    return arch
+
+def get_oss_arch(d):
+    arch = get_oss_machine(d)
+    arch += "-oss"
+    return arch
+
+LAYER_EXTENSION ?= ""
+OSS_MACHINE = "${@get_oss_machine(d)}"
+OSS_LAYER_ARCH = "${@get_oss_arch(d)}${LAYER_EXTENSION}"
+PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
+
+
 # PREFERRED VERSION settings
 PREFERRED_VERSION_bash ?= "3.2.%"
 PREFERRED_VERSION_openssl = "3.0.%"


### PR DESCRIPTION
Reason for change: Configure OSS package arch using tune profile instead of machine name