### PR TITLE
RDKEMW-5776: Memory leaks in gstreamer LSAN/ASAN

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/files/0001-Fix-leak-of-protection-event-value-objects.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/files/0001-Fix-leak-of-protection-event-value-objects.patch
@@ -1,0 +1,31 @@
+From 94c5a97d3cdd5f7d49abc3add71d687eb805ef05 Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Tue, 20 May 2025 11:12:52 +0000
+Subject: [PATCH] Fix leak of protection event value objects
+
+---
+ gst/isomp4/qtdemux.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gst/isomp4/qtdemux.c b/gst/isomp4/qtdemux.c
+index e128b0d..1c72c4a 100644
+--- a/gst/isomp4/qtdemux.c
++++ b/gst/isomp4/qtdemux.c
+@@ -8978,10 +8978,10 @@ gst_qtdemux_request_protection_context_if_needed (GstQTDemux * qtdemux,
+ 
+   g_value_init (&event_list, GST_TYPE_LIST);
+   for (; walk; walk = g_list_previous (walk)) {
+-    GValue *event_value = g_new0 (GValue, 1);
+-    g_value_init (event_value, GST_TYPE_EVENT);
+-    g_value_set_boxed (event_value, walk->data);
+-    gst_value_list_append_and_take_value (&event_list, event_value);
++    GValue event_value = G_VALUE_INIT;
++    g_value_init (&event_value, GST_TYPE_EVENT);
++    g_value_set_boxed (&event_value, walk->data);
++    gst_value_list_append_and_take_value (&event_list, &event_value);
+   }
+ 
+   /*  2a) Query downstream with GST_QUERY_CONTEXT for the context and
+-- 
+2.25.1
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-bad/0f084d46247f9009584b482cea8196b5b871cc73.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-bad/0f084d46247f9009584b482cea8196b5b871cc73.patch
@@ -1,0 +1,104 @@
+From 0f084d46247f9009584b482cea8196b5b871cc73 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <jan.steffens@ltnglobal.com>
+Date: Tue, 2 Feb 2021 18:25:31 +0100
+Subject: [PATCH] h264/h265parse: Add VideoTimeCodeMeta to the outgoing buffer
+
+The parsers attempted to add the meta to the incoming buffer, which
+might not be the outgoing buffer or may not have been writable yet.
+
+To fix this, call `gst_buffer_make_writable` earlier and make sure to
+use the `parse_buffer` to add the meta.
+
+Fixes https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1521
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/2002>
+---
+ gst/videoparsers/gsth264parse.c | 18 +++++++++---------
+ gst/videoparsers/gsth265parse.c | 16 ++++++++--------
+ 2 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/gst/videoparsers/gsth264parse.c b/gst/videoparsers/gsth264parse.c
+index d5f2816e59..a7808b4de3 100644
+--- a/gst/videoparsers/gsth264parse.c
++++ b/gst/videoparsers/gsth264parse.c
+@@ -3134,7 +3134,14 @@ gst_h264_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+   }
+ #endif
+ 
+-  if (!gst_buffer_get_video_time_code_meta (buffer)) {
++  if (frame->out_buffer) {
++    parse_buffer = frame->out_buffer =
++        gst_buffer_make_writable (frame->out_buffer);
++  } else {
++    parse_buffer = frame->buffer = gst_buffer_make_writable (frame->buffer);
++  }
++
++  if (!gst_buffer_get_video_time_code_meta (parse_buffer)) {
+     guint i = 0;
+ 
+     for (i = 0; i < 3 && h264parse->num_clock_timestamp; i++) {
+@@ -3197,7 +3204,7 @@ gst_h264_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+           "Add time code meta %02u:%02u:%02u:%02u",
+           tim->hours_value, tim->minutes_value, tim->seconds_value, n_frames);
+ 
+-      gst_buffer_add_video_time_code_meta_full (buffer,
++      gst_buffer_add_video_time_code_meta_full (parse_buffer,
+           h264parse->parsed_fps_n,
+           h264parse->parsed_fps_d,
+           NULL,
+@@ -3210,13 +3217,6 @@ gst_h264_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+     h264parse->num_clock_timestamp = 0;
+   }
+ 
+-  if (frame->out_buffer) {
+-    parse_buffer = frame->out_buffer =
+-        gst_buffer_make_writable (frame->out_buffer);
+-  } else {
+-    parse_buffer = frame->buffer = gst_buffer_make_writable (frame->buffer);
+-  }
+-
+   if (is_interlaced) {
+     GST_BUFFER_FLAG_SET (parse_buffer, GST_VIDEO_BUFFER_FLAG_INTERLACED);
+     if (h264parse->sei_pic_struct == GST_H264_SEI_PIC_STRUCT_TOP_FIELD)
+diff --git a/gst/videoparsers/gsth265parse.c b/gst/videoparsers/gsth265parse.c
+index e94f86d24f..7747836460 100644
+--- a/gst/videoparsers/gsth265parse.c
++++ b/gst/videoparsers/gsth265parse.c
+@@ -2748,6 +2748,13 @@ gst_h265_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+     }
+   }
+ 
++  if (frame->out_buffer) {
++    parse_buffer = frame->out_buffer =
++        gst_buffer_make_writable (frame->out_buffer);
++  } else {
++    parse_buffer = frame->buffer = gst_buffer_make_writable (frame->buffer);
++  }
++
+   {
+     guint i = 0;
+ 
+@@ -2809,7 +2816,7 @@ gst_h265_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+           gst_util_uint64_scale_int (h265parse->time_code.n_frames[i], 1,
+           2 - h265parse->time_code.units_field_based_flag[i]);
+ 
+-      gst_buffer_add_video_time_code_meta_full (buffer,
++      gst_buffer_add_video_time_code_meta_full (parse_buffer,
+           h265parse->parsed_fps_n,
+           h265parse->parsed_fps_d,
+           NULL,
+@@ -2823,13 +2830,6 @@ gst_h265_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+     }
+   }
+ 
+-  if (frame->out_buffer) {
+-    parse_buffer = frame->out_buffer =
+-        gst_buffer_make_writable (frame->out_buffer);
+-  } else {
+-    parse_buffer = frame->buffer = gst_buffer_make_writable (frame->buffer);
+-  }
+-
+   if (h265parse->sei_pic_struct != GST_H265_SEI_PIC_STRUCT_FRAME) {
+     GST_BUFFER_FLAG_SET (parse_buffer, GST_VIDEO_BUFFER_FLAG_INTERLACED);
+     if (h265parse->sei_pic_struct == GST_H265_SEI_PIC_STRUCT_TOP_FIELD)
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-bad_1.18.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-bad_1.18.5.bb
@@ -17,6 +17,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad
            file://0001-RDKTV-22768-Handle-invalid-nal_unit_length-in-DV-con.patch \
 	   file://0006-RDKDEV-828-Fix-deadlocks-in-gstadaptivedemux.patch \
 	   file://0041-h264parse-h265parse-resend-codec-info-on-reconfig-gst1.18.patch \
+           file://0f084d46247f9009584b482cea8196b5b871cc73.patch \
            "
 SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'sage_svp', 'file://0001-videoparser-remove-h264-h265parse-for-svp.patch', '', d)}"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-base/0001-Fix-decodebin3-caps-leak.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-base/0001-Fix-decodebin3-caps-leak.patch
@@ -1,0 +1,24 @@
+From 56f38294284ff2ca05205ebe3b4af8b035b99c5d Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Tue, 20 May 2025 19:42:28 +0000
+Subject: [PATCH] Fix decodebin3 caps leak
+
+---
+ gst/playback/gstdecodebin3.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gst/playback/gstdecodebin3.c b/gst/playback/gstdecodebin3.c
+index f2614a4..9388978 100644
+--- a/gst/playback/gstdecodebin3.c
++++ b/gst/playback/gstdecodebin3.c
+@@ -654,6 +654,8 @@ gst_decodebin3_dispose (GObject * object)
+   g_list_free (dbin->to_activate);
+   g_list_free (dbin->pending_select_streams);
+   g_clear_object (&dbin->collection);
++  if (dbin->caps)
++    gst_caps_unref (dbin->caps);
+ 
+   free_input (dbin, dbin->main_input);
+ 
+-- 
+2.25.1

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-base_1.18.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-base_1.18.5.bb
@@ -20,6 +20,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-ba
 	   file://516-0008-autoplug-for-sink-decoders.patch \
            file://0006-streamsynchronizer-Consider-streams-having-received-.patch \
            file://0007-LLAMA-14037-fix-deadlock-on-early-flushing-seek.patch \
+           file://0001-Fix-decodebin3-caps-leak.patch \
            "
 SRC_URI += "file://0001-fix-gst-plugins-base-configure-issue-with-dunfell.patch"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-good_1.18.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/gstreamer1.0-plugins-good_1.18.5.bb
@@ -49,6 +49,7 @@ SRC_URI = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-go
 	   file://0044-qtdemux-Handle-Piff-parsing-to-use-sample-properties.patch \
 	   file://0001-reference-senc-box-when-saiz-box-parsing-fails.patch \
 	   file://0049-LLAMA-12494-attach-cbcs-crypt-info-at-the-right-moment.patch \
+           file://0001-Fix-leak-of-protection-event-value-objects.patch \
            "
 SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'sage_svp', 'file://0001-audioparser-remove-eac3-aacparse-for-svp.patch', '', d)}"
 


### PR DESCRIPTION
Reason for change : pulling rdkv changes into rdke for gstreamer plugins
Test Procedure    : None
Priority          : P1
Risks             : None
Signed-off-by     : daya_christudasan@comcast.com