### PR TITLE
RDKOSS-426: Bring Vulkan benchmark recipies to OSS layer

### DIFF
--- a/recipes-benchmark/vkmark/vkmark/0001-vulkan-registry-path-prefix.patch
+++ b/recipes-benchmark/vkmark/vkmark/0001-vulkan-registry-path-prefix.patch
@@ -1,0 +1,15 @@
+diff --git a/src/meson.build b/src/meson.build
+index 5c543d6..126a10d 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -1,7 +1,9 @@
+ prog_python = find_program('python3')
+ 
++vulkan_registry_path_prefix = meson.get_cross_property('sys_root', '/') + vulkan_dep.get_pkgconfig_variable('prefix')
++
+ vk_xml = join_paths([
+-    vulkan_dep.get_pkgconfig_variable('prefix'),
++    vulkan_registry_path_prefix,
+     'share', 'vulkan', 'registry',
+     'vk.xml'
+     ])

--- a/recipes-benchmark/vkmark/vkmark/0002-vkmark-build.patch
+++ b/recipes-benchmark/vkmark/vkmark/0002-vkmark-build.patch
@@ -1,0 +1,17 @@
+Index: git/src/vulkan_state.cpp
+===================================================================
+--- git.orig/src/vulkan_state.cpp	2025-03-30 09:47:39.249179576 +0000
++++ git/src/vulkan_state.cpp	2025-03-30 09:44:49.034184090 +0000
+@@ -47,10 +47,10 @@
+     DebugUtilsDispatcher(vk::Instance& instance) :
+         vkCreateDebugUtilsMessengerEXT(
+             PFN_vkCreateDebugUtilsMessengerEXT(
+-                vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"))),
++                vkGetInstanceProcAddr(static_cast<VkInstance>(instance), "vkCreateDebugUtilsMessengerEXT"))),
+         vkDestroyDebugUtilsMessengerEXT(
+             PFN_vkDestroyDebugUtilsMessengerEXT(
+-                vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT")))
++                vkGetInstanceProcAddr(static_cast<VkInstance>(instance), "vkDestroyDebugUtilsMessengerEXT")))
+     {
+     }
+ 

--- a/recipes-benchmark/vkmark/vkmark/0003-vkmark-xdg-shell.patch
+++ b/recipes-benchmark/vkmark/vkmark/0003-vkmark-xdg-shell.patch
@@ -1,0 +1,25 @@
+Index: git/src/ws/wayland_native_system.cpp
+===================================================================
+--- git.orig/src/ws/wayland_native_system.cpp	2025-03-30 04:23:18.205937597 +0000
++++ git/src/ws/wayland_native_system.cpp	2025-03-17 09:02:56.000000000 +0000
+@@ -236,6 +236,7 @@
+     if (!surface)
+         throw std::runtime_error("Failed to create Wayland surface");
+ 
++#if defined(XDG_WM_BASE_PROTO)
+     if (!xdg_wm_base)
+     {
+         throw std::runtime_error(
+@@ -260,10 +261,11 @@
+ 
+     xdg_toplevel_set_app_id(xdg_toplevel, "com.github.vkmark.vkmark");
+     xdg_toplevel_set_title(xdg_toplevel, "vkmark " VKMARK_VERSION_STR);
++#endif
+ 
+     if (fullscreen_requested())
+     {
+-        xdg_toplevel_set_fullscreen(xdg_toplevel, output);
++//        xdg_toplevel_set_fullscreen(xdg_toplevel, output);
+         vk_extent = vk::Extent2D{
+             static_cast<uint32_t>(output_width),
+             static_cast<uint32_t>(output_height)};

--- a/recipes-benchmark/vkmark/vkmark_%.bbappend
+++ b/recipes-benchmark/vkmark/vkmark_%.bbappend
@@ -1,0 +1,4 @@
+
+SRC_URI:append = " file://0001-vulkan-registry-path-prefix.patch"
+SRC_URI:append = " file://0002-vkmark-build.patch"
+SRC_URI:append = " file://0003-vkmark-xdg-shell.patch"

--- a/recipes-benchmark/vkmark/vkmark_git.bb
+++ b/recipes-benchmark/vkmark/vkmark_git.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Vulkan Benchmark"
+DESCRIPTION = "vkmark is an extensible Vulkan benchmarking suite with targeted, configurable scenes."
+AUTHOR = "Collabora"
+HOMEPAGE = "https://github.com/vkmark/vkmark"
+BUGTRACKER = "https://github.com/vkmark/vkmark/issues"
+SECTION = "graphics"
+CVE_PRODUCT = ""
+LICENSE = "LGPL2.1"
+LIC_FILES_CHKSUM = "file://COPYING-LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
+
+inherit meson pkgconfig features_check
+
+DEPENDS += "assimp glm vulkan-headers vulkan-loader"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+SRC_URI = "git://github.com/vkmark/vkmark.git;protocol=https;nobranch=1"
+
+SRCREV ?= "36e7d9b2ecf723e876add65534e95f55ec1bc79d"
+
+S = "${WORKDIR}/git"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland xcb', d)}"
+
+PACKAGECONFIG[kms] = "-Dkms=true,-Dkms=false,drm virtual/libgbm"
+PACKAGECONFIG[wayland] = "-Dwayland=true,-Dwayland=false,wayland wayland-native wayland-protocols"
+PACKAGECONFIG[xcb] = "-Dxcb=true,-Dxcb=false,virtual/libx11 libxcb"
+
+do_write_config:append(){
+   sed -i "/\[properties\]/asys_root=\'${STAGING_DIR_TARGET}\'" ${WORKDIR}/meson.cross
+}
+
+do_install:append () {
+   rm -rf ${D}${datadir}/man
+}
+
+FILES:${PN} += "${bindir}"
+FILES:${PN} += "${libdir}"
+FILES:${PN} += "${datadir}"


### PR DESCRIPTION
Reason for the change: This change introduces vkmark utility, which is an benchmark utility can be used for testing vulkan.

Signed-off-by: rajesh_gangadharan@comcast.com