### PR TITLE
Feature RDKB Scarthgap

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_COLLECTIONS += "oss-reference"
 BBFILE_PATTERN_oss-reference := "^${LAYERDIR}/"
 BBFILE_PRIORITY_oss-reference = "6"
 
-LAYERSERIES_COMPAT_oss-reference = "dunfell kirkstone"
+LAYERSERIES_COMPAT_oss-reference = "dunfell kirkstone scarthgap"
 LAYERDEPENDS_oss-reference = "core multimedia-layer"
 
 BBMASK .= "|poky/meta/recipes-core/os-release/os-release.bb"

--- a/recipes-connectivity/openssl/openssl/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
+++ b/recipes-connectivity/openssl/openssl/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
@@ -1,0 +1,76 @@
+From 3e1d00481093e10775eaf69d619c45b32a4aa7dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Hundeb=C3=B8ll?= <martin@geanix.com>
+Date: Tue, 6 Nov 2018 14:50:47 +0100
+Subject: [PATCH] buildinfo: strip sysroot and debug-prefix-map from compiler
+ info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The openssl build system generates buildinf.h containing the full
+compiler command line used to compile objects. This breaks
+reproducibility, as the compile command is baked into libcrypto, where
+it is used when running `openssl version -f`.
+
+Add stripped build variables for the compiler and cflags lines, and use
+those when generating buildinfo.h.
+
+This is based on a similar patch for older openssl versions:
+https://patchwork.openembedded.org/patch/147229/
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Martin Hundebøll <martin@geanix.com>
+
+
+Update to fix buildpaths qa issue for '-fmacro-prefix-map'.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+ Configurations/unix-Makefile.tmpl | 10 +++++++++-
+ crypto/build.info                 |  2 +-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 16af4d2087..54c162784c 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -317,13 +317,22 @@ BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
+                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+ BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+ 
+-# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
++# *_Q variables are used for one thing only: to build up buildinf.h
+ CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;
+               $cppflags2 =~ s|([\\"])|\\$1|g;
+               $lib_cppflags =~ s|([\\"])|\\$1|g;
+               join(' ', $lib_cppflags || (), $cppflags2 || (),
+                         $cppflags1 || ()) -}
+ 
++CFLAGS_Q={- for (@{$config{CFLAGS}}) {
++              s|-fdebug-prefix-map=[^ ]+|-fdebug-prefix-map=|g;
++              s|-fmacro-prefix-map=[^ ]+|-fmacro-prefix-map=|g;
++            }
++            join(' ', @{$config{CFLAGS}}) -}
++
++CC_Q={- $config{CC} =~ s|--sysroot=[^ ]+|--sysroot=recipe-sysroot|g;
++        join(' ', $config{CC}) -}
++
+ PERLASM_SCHEME= {- $target{perlasm_scheme} -}
+ 
+ # For x86 assembler: Set PROCESSOR to 386 if you want to support
+diff --git a/crypto/build.info b/crypto/build.info
+index b515b7318e..8c9cee2a09 100644
+--- a/crypto/build.info
++++ b/crypto/build.info
+@@ -10,7 +10,7 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
+         ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl
+ 
+ DEPEND[cversion.o]=buildinf.h
+-GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
++GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC_Q) $(CFLAGS_Q) $(CPPFLAGS_Q)" "$(PLATFORM)"
+ DEPEND[buildinf.h]=../configdata.pm
+ 
+ GENERATE[uplink-x86.s]=../ms/uplink-x86.pl $(PERLASM_SCHEME)
+-- 
+2.19.1
+

--- a/recipes-core/dbus/dbus_%.bbappend
+++ b/recipes-core/dbus/dbus_%.bbappend
@@ -5,7 +5,7 @@ SRC_URI:append = " \
 "
 
 SRC_URI:append:broadband = " \
-    file://01-dbus-ccsp-apis-${PV}.patch \
+    file://01-dbus-ccsp-apis-1.14.8.patch \
 "
 
 #Removed --with-xml expact as the configuration is not supported in 1.14. It was not supported in dunfell version 1.12.16 as well.

--- a/recipes-core/volatile-binds/volatile-binds.bb
+++ b/recipes-core/volatile-binds/volatile-binds.bb
@@ -79,5 +79,5 @@ do_install:append:broadband ()  {
 do_install[dirs] = "${WORKDIR}"
 
 SYSTEMD_SERVICE:${PN} += "var-lib.mount"
-SYSTEMD_SERVICE:${PN}:remove_broadband += "var-lib.mount"
-FILES:${PN}:remove_broadband += "${systemd_unitdir}/system/var-lib.mount"
+SYSTEMD_SERVICE:${PN}:remove:broadband += "var-lib.mount"
+FILES:${PN}:remove:broadband += "${systemd_unitdir}/system/var-lib.mount"

--- a/recipes-core/zlib/zlib_1.2.11.bb
+++ b/recipes-core/zlib/zlib_1.2.11.bb
@@ -7,7 +7,6 @@ LICENSE = "Zlib"
 LIC_FILES_CHKSUM = "file://zlib.h;beginline=6;endline=23;md5=5377232268e952e9ef63bc555f7aa6c0"
 
 SRC_URI = "${SOURCEFORGE_MIRROR}/libpng/${BPN}/${PV}/${BPN}-${PV}.tar.xz \
-           file://remove.ldconfig.call.patch \
            file://Makefile-runtests.patch \
            file://ldflags-tests.patch \
            file://run-ptest \

--- a/recipes-devtools/python/python3_3.12.9.bbappend
+++ b/recipes-devtools/python/python3_3.12.9.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:python3-db += "gdbm-compat"

--- a/recipes-support/ca-certificates/files/005_modify_CA_Bundle_path_kirkstone.patch
+++ b/recipes-support/ca-certificates/files/005_modify_CA_Bundle_path_kirkstone.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] RDKALL-1221: Create separate CA bundles for browser apps
 	This patch is made compatible to kirkstone Yocto version.
 Source: COMCAST 02060561db73c28bcb9dff8d241c2275c6ad9b47 Mar 22, 2019 2:49 PM
 Signed-off-by: Arjun <arjun_daasuramdass@comcast.com>
+Upstream-Status: Pending
 ---
 
 --- a/sbin/update-ca-certificates	2022-10-31 11:35:36.417666102 +0000

--- a/recipes-support/webcfg/webcfg_1.0.bb
+++ b/recipes-support/webcfg/webcfg_1.0.bb
@@ -19,7 +19,7 @@ S = "${WORKDIR}/git"
 
 ASNEEDED = ""
 
-inherit pkgconfig cmake ${@bb.utils.contains("DISTRO_FEATURES", "kirkstone", "python3native", "pythonnative", d)}
+inherit pkgconfig cmake ${@bb.utils.contains_any("DISTRO_FEATURES", "kirkstone scarthgap", "python3native", "pythonnative", d)}
 
 EXTRA_OECMAKE = "-DBUILD_TESTING=OFF -DBUILD_YOCTO=true"
 


### PR DESCRIPTION
RDKBACCL-966 : Changes for OSS consumption build
Reason for change: Changes for meta-rdk-oss-reference
Changes to fix the scarthgap based syntax errors
Revisit for recreating patch