### PR TITLE
RDKE-904, DELIA-68725: fix network process hang in io_try_write

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -533,7 +533,7 @@ PACKAGE_ARCH:pn-libsndfile1 = "${OSS_LAYER_ARCH}"
 PR:pn-libsolv = "r0"
 PACKAGE_ARCH:pn-libsolv = "${OSS_LAYER_ARCH}"
 
-PR:pn-libsoup = "r0"
+PR:pn-libsoup = "r1"
 PACKAGE_ARCH:pn-libsoup = "${OSS_LAYER_ARCH}"
 
 PR:pn-libsoup-2.4 = "r1"

--- a/recipes-support/libsoup/files/0001-http2-set-error-on-zero-return-from-write.patch
+++ b/recipes-support/libsoup/files/0001-http2-set-error-on-zero-return-from-write.patch
@@ -1,0 +1,34 @@
+From ac865c51137dad2692fa1a8a7cee1a6d575f5c39 Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Tue, 19 Aug 2025 19:55:05 +0000
+Subject: [PATCH 1/3] [http2] set error on zero return from write
+
+Sometimes servers try to close (close_notify alert) the TLS connection
+before all data was transmitted. This results in 0 returned for every
+write. That indicates TLS connection is closed(SSL_write returns SSL_ERROR_ZERO_RETURN),
+but underlying socket connection is still open. Resulting in infinite loop in io_try_write.
+---
+ libsoup/http2/soup-client-message-io-http2.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/libsoup/http2/soup-client-message-io-http2.c b/libsoup/http2/soup-client-message-io-http2.c
+index 1e8e8a71..79027ecd 100644
+--- a/libsoup/http2/soup-client-message-io-http2.c
++++ b/libsoup/http2/soup-client-message-io-http2.c
+@@ -372,6 +372,13 @@ io_write (SoupClientMessageIOHTTP2 *io,
+         if (ret < 0)
+                 return FALSE;
+ 
++        if (ret == 0) {
++                g_set_error_literal (error, G_IO_ERROR,
++                                     G_IO_ERROR_PARTIAL_INPUT,
++                                     _("Connection terminated unexpectedly"));
++                return FALSE;
++        }
++
+         io->written_bytes += ret;
+         return TRUE;
+ }
+-- 
+2.34.1
+

--- a/recipes-support/libsoup/files/0002-http2-improve-handling-of-io-error-thrown-early-afte.patch
+++ b/recipes-support/libsoup/files/0002-http2-improve-handling-of-io-error-thrown-early-afte.patch
@@ -1,0 +1,43 @@
+From 5235703b5c541a874a702c6881721e5d585bf0ba Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Tue, 19 Aug 2025 20:01:55 +0000
+Subject: [PATCH 2/3] [http2] improve handling of io error thrown early after
+ handshake
+
+---
+ libsoup/http2/soup-client-message-io-http2.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/libsoup/http2/soup-client-message-io-http2.c b/libsoup/http2/soup-client-message-io-http2.c
+index 79027ecd..251a2234 100644
+--- a/libsoup/http2/soup-client-message-io-http2.c
++++ b/libsoup/http2/soup-client-message-io-http2.c
+@@ -609,8 +609,13 @@ io_try_sniff_content (SoupHTTP2MessageData *data,
+ static void
+ soup_client_message_io_http2_terminate_session (SoupClientMessageIOHTTP2 *io)
+ {
+-        if (io->session_terminated)
++        if (io->session_terminated) {
++                if (io->close_task && !io->goaway_sent && io->error) {
++                        g_task_return_boolean (io->close_task, TRUE);
++                        g_clear_object (&io->close_task);
++                }
+                 return;
++        }
+ 
+         if (g_hash_table_size (io->messages) != 0)
+                 return;
+@@ -1534,6 +1539,10 @@ send_message_request (SoupMessage          *msg,
+                 data->stream_id = stream_id;
+                 h2_debug (io, data, "[SESSION] Request made for %s%s", authority_header, path_and_query);
+                 io_try_write (io, !data->item->async);
++                if (io->error && !data->error) {
++                        set_error_for_data(data, g_error_copy (io->error));
++                        io->is_shutdown = TRUE;
++                }
+         }
+         g_array_free (headers, TRUE);
+         g_free (authority);
+-- 
+2.34.1
+

--- a/recipes-support/libsoup/files/0003-http2-fix-crash-in-on_data_read-after-connection-has.patch
+++ b/recipes-support/libsoup/files/0003-http2-fix-crash-in-on_data_read-after-connection-has.patch
@@ -1,0 +1,76 @@
+From 98434405a86a70bce0be81d3bedfc92eb55e1123 Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Tue, 19 Aug 2025 20:02:48 +0000
+Subject: [PATCH 3/3] [http2] fix crash in on_data_read after connection has
+ been destroyed
+
+---
+ libsoup/http2/soup-client-message-io-http2.c | 29 +++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/libsoup/http2/soup-client-message-io-http2.c b/libsoup/http2/soup-client-message-io-http2.c
+index 251a2234..f7c68736 100644
+--- a/libsoup/http2/soup-client-message-io-http2.c
++++ b/libsoup/http2/soup-client-message-io-http2.c
+@@ -103,6 +103,8 @@ typedef struct {
+         GByteArray *data_source_buffer;
+         GError *data_source_error;
+         gboolean data_source_eof;
++        GCancellable *data_source_cancellable;
++        gulong data_source_cancellable_id;
+ 
+         SoupClientMessageIOHTTP2 *io; /* Unowned */
+         SoupMessageIOCompletionFn completion_cb;
+@@ -1196,6 +1198,14 @@ log_request_data (SoupHTTP2MessageData *data,
+         soup_logger_log_request_data (data->logger, data->msg, (const char *)buffer, len);
+ }
+ 
++static void
++on_data_source_cancelled (GCancellable *cancellable,
++                          gpointer      data)
++{
++        GCancellable *linked_cancellable = G_CANCELLABLE (data);
++        g_cancellable_cancel (linked_cancellable);
++}
++
+ static ssize_t
+ on_data_source_read_callback (nghttp2_session     *session,
+                               int32_t              stream_id,
+@@ -1327,9 +1337,17 @@ on_data_source_read_callback (nghttp2_session     *session,
+                 } else {
+                         h2_debug (data->io, data, "[SEND_BODY] Reading async");
+                         g_byte_array_set_size (data->data_source_buffer, length);
++                        if (!data->data_source_cancellable) {
++                                data->data_source_cancellable = g_cancellable_new ();
++                                if (data->item->cancellable) {
++                                        data->data_source_cancellable_id =
++                                                g_cancellable_connect (data->item->cancellable, G_CALLBACK (on_data_source_cancelled),
++                                                                       g_object_ref (data->data_source_cancellable),  g_object_unref);
++                                }
++                        }
+                         g_input_stream_read_async (in_stream, data->data_source_buffer->data, length,
+                                                    get_data_io_priority (data),
+-                                                   data->item->cancellable,
++                                                   data->data_source_cancellable,
+                                                    (GAsyncReadyCallback)on_data_read, data);
+                         data->io->in_callback--;
+                         return NGHTTP2_ERR_DEFERRED;
+@@ -1414,6 +1432,15 @@ soup_http2_message_data_close (SoupHTTP2MessageData *data)
+                 g_clear_object (&data->body_istream);
+         }
+ 
++        if (data->data_source_cancellable_id) {
++                g_cancellable_disconnect (data->item->cancellable, data->data_source_cancellable_id);
++                data->data_source_cancellable_id = 0;
++        }
++        if (data->data_source_cancellable) {
++                g_cancellable_cancel(data->data_source_cancellable);
++                g_clear_object(&data->data_source_cancellable);
++        }
++
+         if (data->msg)
+                 g_signal_handlers_disconnect_by_data (data->msg, data);
+ 
+-- 
+2.34.1
+

--- a/recipes-support/libsoup/libsoup_3.6.5.bb
+++ b/recipes-support/libsoup/libsoup_3.6.5.bb
@@ -15,6 +15,9 @@ SRC_URI = "${GNOME_MIRROR}/libsoup/${SHRT_VER}/libsoup-${PV}.tar.xz"
 SRC_URI[sha256sum] = "6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
 
 SRC_URI += "file://comcast-RDK-56000-Cookie-size-limit-log_3.0.patch"
+SRC_URI += "file://0001-http2-set-error-on-zero-return-from-write.patch"
+SRC_URI += "file://0002-http2-improve-handling-of-io-error-thrown-early-afte.patch"
+SRC_URI += "file://0003-http2-fix-crash-in-on_data_read-after-connection-has.patch"
 
 PROVIDES = "libsoup-3.0"
 CVE_PRODUCT = "libsoup"


### PR DESCRIPTION
Reason for change: Sometimes servers try to close (close_notify alert) the TLS connection before all data was transmitted. This results in 0 returned for every write. That indicates TLS connection is closed(SSL_write returns SSL_ERROR_ZERO_RETURN), but underlying socket connection is still open. Resulting in infinite loop in io_try_write. Upstream:
https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/477 https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/479 Test Procedure: Smoke test of web apps
Risks: Low
Priority: P0
Change-Id: If2e9c1023382c3ab888d85b1591ba4e6e686d759