### PR TITLE
RDKOSS-468: Add fix for WRONG_KEY retry logic and dnsmasq started by NetworkManager

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -167,7 +167,7 @@ PACKAGE_ARCH:pn-dbus-glib = "${OSS_LAYER_ARCH}"
 PR:pn-dibbler= "r1"
 PACKAGE_ARCH:pn-dibbler = "${OSS_LAYER_ARCH}"
 
-PR:pn-dnsmasq = "r1"
+PR:pn-dnsmasq = "r2"
 PACKAGE_ARCH:pn-dnsmasq = "${OSS_LAYER_ARCH}"
 
 PR:pn-dosfstools = "r0"
@@ -656,7 +656,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r0"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r6"
+PR:pn-networkmanager = "r7"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM_autoconnect_retry.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM_autoconnect_retry.patch
@@ -1,0 +1,29 @@
+Date: Sep 09 2025
+From: Aravindan NC <nc.aravindan@gmail.com>
+Subject: Do not block retry for WRONG_KEY
+Source: RDKCENTRAL
+Signed-off-by: Aravindan NC <nc.aravindan@gmail.com>
+Index: NetworkManager-1.43.7/src/core/nm-policy.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/nm-policy.c
++++ NetworkManager-1.43.7/src/core/nm-policy.c
+@@ -1998,13 +1998,13 @@ device_state_changed(NMDevice
+                 con_v = nm_settings_connection_get_last_secret_agent_version_id(sett_conn);
+                 if (con_v == 0 || con_v == nm_agent_manager_get_agent_version_id(priv->agent_mgr)) {
+                     _LOGD(LOGD_DEVICE,
+-                          "connection '%s' now blocked from autoconnect due to no secrets",
++                          "connection '%s' now retrying autoconnect due to no secrets",
+                           nm_settings_connection_get_id(sett_conn));
+-                    nm_settings_connection_autoconnect_blocked_reason_set(
+-                        sett_conn,
+-                        NM_SETTINGS_AUTOCONNECT_BLOCKED_REASON_NO_SECRETS,
+-                        TRUE);
+-                    blocked = TRUE;
++                    //nm_settings_connection_autoconnect_blocked_reason_set(
++                    //    sett_conn,
++                    //    NM_SETTINGS_AUTOCONNECT_BLOCKED_REASON_NO_SECRETS,
++                    //    TRUE);
++                    blocked = FALSE;
+                 }
+             } else if (nm_device_state_reason_check(reason)
+                        == NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED) {

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
@@ -1,6 +1,7 @@
 [main]
 plugins=ifupdown,keyfile
 autoconnect-retries-default=0
+dns=dnsmasq
 
 [ifupdown]
 managed=true

--- a/recipes-connectivity/networkmanager/networkmanager/dnsmasq-logging.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/dnsmasq-logging.conf
@@ -1,0 +1,2 @@
+log-facility=/opt/logs/dnsmasq.log
+log-async

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -28,6 +28,7 @@ SRC_URI = " \
     file://NM-wpa-service.patch \
     file://readline_NM.patch \
     file://NM_Dispatcher.patch \
+    file://dnsmasq-logging.conf \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -212,10 +212,7 @@ FILES:${PN}-daemon += " \
     ${sysconfdir}/sysconfig/network-scripts \
     ${systemd_system_unitdir} \
 "
-FILES:${PN}:remove = "${sysconfdir}/resolv.dnsmasq"
-FILES:${PN}:remove = "${sysconfdir}/resolv.conf"
-FILES:${PN}-daemon:remove = "${sysconfdir}/resolv.conf"
-FILES:${PN}-daemon:remove = "${sysconfdir}/resolv.dnsmasq"
+
 FILES:${PN}-daemon:remove = "${systemd_system_unitdir}/NetworkManager-wait-online.service"
 #{nonarch_libdir}/NetworkManager/system-connections
 RDEPENDS:${PN}-daemon += "\
@@ -249,8 +246,10 @@ do_install:append() {
     install -d ${D}${sysconfdir}
     install -d ${D}${sysconfdir}/NetworkManager/
     install -d ${D}${sysconfdir}/NetworkManager/conf.d/
+    install -d ${D}${sysconfdir}/NetworkManager/dnsmasq.d/
     install ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/NetworkManager.conf
-    install ${WORKDIR}/95-logging.conf ${D}${sysconfdir}/NetworkManager/conf.d/95-logging.conf
+    install ${WORKDIR}/95-logging.conf ${D}${sysconfdir}/NetworkManager/conf.d/95-logging.conf\
+    install ${WORKDIR}/dnsmasq-logging.conf ${D}${sysconfdir}/NetworkManager/dnsmasq.d/dnsmasq-logging.conf
 
     install -Dm 0755 ${WORKDIR}/${BPN}.initd ${D}${sysconfdir}/init.d/network-manager
 

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -29,6 +29,7 @@ SRC_URI = " \
     file://readline_NM.patch \
     file://NM_Dispatcher.patch \
     file://dnsmasq-logging.conf \
+    file://NM_autoconnect_retry.patch \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -248,7 +248,7 @@ do_install:append() {
     install -d ${D}${sysconfdir}/NetworkManager/conf.d/
     install -d ${D}${sysconfdir}/NetworkManager/dnsmasq.d/
     install ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/NetworkManager.conf
-    install ${WORKDIR}/95-logging.conf ${D}${sysconfdir}/NetworkManager/conf.d/95-logging.conf\
+    install ${WORKDIR}/95-logging.conf ${D}${sysconfdir}/NetworkManager/conf.d/95-logging.conf
     install ${WORKDIR}/dnsmasq-logging.conf ${D}${sysconfdir}/NetworkManager/dnsmasq.d/dnsmasq-logging.conf
 
     install -Dm 0755 ${WORKDIR}/${BPN}.initd ${D}${sysconfdir}/init.d/network-manager

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -45,3 +45,5 @@ FILES:${PN}-service = "${systemd_unitdir}/system/* \
                        ${base_libdir}/rdk/* \
                       "
 SYSTEMD_SERVICE:${PN}-service  = "dnsmasq.service"
+SYSTEMD_SERVICE:${PN}:remove  = "dnsmasq.service"
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -24,25 +24,26 @@ LOGROTATE_ROTATION_dnsmasq="3"
 LOGROTATE_SIZE_MEM_dnsmasq="1572864"
 LOGROTATE_ROTATION_MEM_dnsmasq="3"
 
+PACKAGECONFIG:append = " dbus"
+PACKAGECONFIG[dbus] = "--enable-dbus,--disable-dbus,dbus"
+# dnsmasq-service package will contain dnsmasq.service and dnsmasqLauncher.sh
+# By default, NetworkManager will start and manage dnsmasq. 
+# If you wish to use dnsmasq as a standlaone service through this package, make sure to disable dnsmasq configuration in NetworkManager.
+PACKAGES =+ "${PN}-service"
+
 do_install:append() {
      install -d ${D}${base_libdir}/rdk
      install -m 0644 ${WORKDIR}/dnsmasq.service ${D}${systemd_unitdir}/system
      sed -i -- 's/#resolv-file=/resolv-file="\/etc\/resolv.dnsmasq"/g' ${D}/etc/dnsmasq.conf
      sed -i -- 's/#user=/user=root/g' ${D}/etc/dnsmasq.conf
      sed -i -- 's/#dhcp-leasefile=\/var\/lib\/misc\/dnsmasq.leases/dhcp-leasefile=\/tmp\/dnsmasq.leases/g' ${D}/etc/dnsmasq.conf
-     touch ${D}${sysconfdir}/resolv.conf
-     echo "nameserver 127.0.0.1" > ${D}${sysconfdir}/resolv.conf
-     echo "options timeout:1" >> ${D}${sysconfdir}/resolv.conf
-     echo "options attempts:2" >> ${D}${sysconfdir}/resolv.conf
-     touch ${D}${sysconfdir}/resolv.dnsmasq
      install -m 0755 ${S}/../dnsmasqLauncher.sh ${D}${base_libdir}/rdk
      install -D -m 0644 ${WORKDIR}/dns.conf ${D}${systemd_unitdir}/system/dnsmasq.service.d/dns.conf
 }
 
 RDEPENDS:${PN} += "busybox"
 
-FILES:${PN}:append = " ${sysconfdir}/resolv.conf \
-                       ${sysconfdir}/resolv.dnsmasq \
+FILES:${PN}-service = "${systemd_unitdir}/system/* \
                        ${base_libdir}/rdk/* \
                       "
-FILES:${PN} += " ${systemd_unitdir}/system/dnsmasq.service.d/dns.conf"
+SYSTEMD_SERVICE:${PN}-service  = "dnsmasq.service"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -3,8 +3,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://dnsmasq.service"
 
 SRC_URI += "file://dns.conf"
-
-CFLAGS += " -DNO_INOTIFY"
      
 SRC_URI += "file://dnsmasqLauncher.sh"
 SRC_URI:append:broadband += "file://dnsmasq_syslog_quiet.patch"


### PR DESCRIPTION
Reason for change: Add retry logic for WRONG_KEY and dnsmasq start by NetworkManager
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)