### PR TITLE
RDKOSS-468: Add fix for WRONG_KEY retry logic and dnsmasq started by NetworkManager

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -191,7 +191,7 @@ PACKAGE_ARCH:pn-dbus-glib = "${OSS_LAYER_ARCH}"
 PR:pn-dibbler= "r1"
 PACKAGE_ARCH:pn-dibbler = "${OSS_LAYER_ARCH}"
 
-PR:pn-dnsmasq = "r3"
+PR:pn-dnsmasq = "r4"
 PACKAGE_ARCH:pn-dnsmasq = "${OSS_LAYER_ARCH}"
 
 PR:pn-dosfstools = "r0"
@@ -686,7 +686,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r1"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r9"
+PR:pn-networkmanager = "r10"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM_autoconnect_retry.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM_autoconnect_retry.patch
@@ -1,0 +1,24 @@
+Index: NetworkManager-1.43.7/src/core/nm-policy.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/nm-policy.c
++++ NetworkManager-1.43.7/src/core/nm-policy.c
+@@ -1998,13 +1998,13 @@ device_state_changed(NMDevice
+                 con_v = nm_settings_connection_get_last_secret_agent_version_id(sett_conn);
+                 if (con_v == 0 || con_v == nm_agent_manager_get_agent_version_id(priv->agent_mgr)) {
+                     _LOGD(LOGD_DEVICE,
+-                          "connection '%s' now blocked from autoconnect due to no secrets",
++                          "connection '%s' now retrying autoconnect due to no secrets",
+                           nm_settings_connection_get_id(sett_conn));
+-                    nm_settings_connection_autoconnect_blocked_reason_set(
+-                        sett_conn,
+-                        NM_SETTINGS_AUTOCONNECT_BLOCKED_REASON_NO_SECRETS,
+-                        TRUE);
+-                    blocked = TRUE;
++                    //nm_settings_connection_autoconnect_blocked_reason_set(
++                    //    sett_conn,
++                    //    NM_SETTINGS_AUTOCONNECT_BLOCKED_REASON_NO_SECRETS,
++                    //    TRUE);
++                    blocked = FALSE;
+                 }
+             } else if (nm_device_state_reason_check(reason)
+                        == NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED) {

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -32,6 +32,7 @@ SRC_URI = " \
     file://org.freedesktop.nm_connectivity.service \
     file://0001-wifi-don-t-recheck-auto-activate-on-disposal.patch \
     file://dnsmasq-logging.conf \
+    file://NM_autoconnect_retry.patch \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -3,11 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://dnsmasq.service"
 
 SRC_URI += "file://dns.conf"
-
-CFLAGS += " -DNO_INOTIFY"
-
+     
 SRC_URI += "file://dnsmasqLauncher.sh"
-
 SRC_URI:append:broadband += "file://dnsmasq_syslog_quiet.patch"
 
 inherit syslog-ng-config-gen logrotate_config
@@ -43,7 +40,10 @@ do_install:append() {
 }
 
 RDEPENDS:${PN} += "busybox"
+
 FILES:${PN}-service = "${systemd_unitdir}/system/* \
                        ${base_libdir}/rdk/* \
                       "
 SYSTEMD_SERVICE:${PN}-service  = "dnsmasq.service"
+SYSTEMD_SERVICE:${PN}:remove  = "dnsmasq.service"
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -40,6 +40,7 @@ do_install:append() {
 }
 
 RDEPENDS:${PN} += "busybox"
+RDEPENDS:${PN}-service += "busybox"
 
 FILES:${PN}-service = "${systemd_unitdir}/system/* \
                        ${base_libdir}/rdk/* \


### PR DESCRIPTION
Reason for change: Add retry logic for WRONG_KEY and dnsmasq start by NetworkManager
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)