### PR TITLE
RDKOSS-468: Add RDEPENDS for service package

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -167,7 +167,7 @@ PACKAGE_ARCH:pn-dbus-glib = "${OSS_LAYER_ARCH}"
 PR:pn-dibbler= "r1"
 PACKAGE_ARCH:pn-dibbler = "${OSS_LAYER_ARCH}"
 
-PR:pn-dnsmasq = "r2"
+PR:pn-dnsmasq = "r3"
 PACKAGE_ARCH:pn-dnsmasq = "${OSS_LAYER_ARCH}"
 
 PR:pn-dosfstools = "r0"

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -40,6 +40,7 @@ do_install:append() {
 }
 
 RDEPENDS:${PN} += "busybox"
+RDEPENDS:${PN}-service += "busybox"
 
 FILES:${PN}-service = "${systemd_unitdir}/system/* \
                        ${base_libdir}/rdk/* \


### PR DESCRIPTION
Reason for change: Add retry logic for WRONG_KEY and dnsmasq start by NetworkManager
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)