### PR TITLE
RDKOSS-467 : Added DAB required missing dependencies

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -230,6 +230,9 @@ PACKAGE_ARCH:pn-flac = "${OSS_LAYER_ARCH}"
 PR:pn-flex = "r0"
 PACKAGE_ARCH:pn-flex = "${OSS_LAYER_ARCH}"
 
+PR:pn-fmt = "r0"
+PACKAGE_ARCH:pn-fmt = "${OSS_LAYER_ARCH}"
+
 PR:pn-fontconfig = "r0"
 PACKAGE_ARCH:pn-fontconfig = "${OSS_LAYER_ARCH}"
 
@@ -656,6 +659,9 @@ PACKAGE_ARCH:pn-minizip = "${OSS_LAYER_ARCH}"
 PR:pn-mongoose = "r0"
 PACKAGE_ARCH:pn-mongoose = "${OSS_LAYER_ARCH}"
 
+PR:pn-mosquitto = "r0"
+PACKAGE_ARCH:pn-mosquitto = "${OSS_LAYER_ARCH}"
+
 PR:pn-msgpack-c = "r0"
 PACKAGE_ARCH:pn-msgpack-c = "${OSS_LAYER_ARCH}"
 
@@ -724,6 +730,9 @@ PACKAGE_ARCH:pn-opkg-utils = "${OSS_LAYER_ARCH}"
 
 PR:pn-orc = "r0"
 PACKAGE_ARCH:pn-orc = "${OSS_LAYER_ARCH}"
+
+PR:pn-paho-mqtt-c = "r0"
+PACKAGE_ARCH:pn-paho-mqtt-c = "${OSS_LAYER_ARCH}"
 
 PR:pn-perl = "r0"
 PACKAGE_ARCH:pn-perl = "${OSS_LAYER_ARCH}"

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -181,6 +181,7 @@ RDEPENDS:${PN} += "\
      ebtables \
      ethtool \
      evtest \
+     fmt \
      gflags \
      googletest \
      grpc \
@@ -210,12 +211,14 @@ RDEPENDS:${PN} += "\
      lua \
      lvm2 \
      mdns \
+     mosquitto \
      msgpack-c \
      ndisc6-rdnssd \
      ne10 \
      nspr \
      nss \
      openjpeg \
+     paho-mqtt-c \
      protobuf \
      protobuf-c \
      qrencode \


### PR DESCRIPTION
Reason for change: DAB requirement for YouTube certification