### PR TITLE
RDKOSS-467: include_dir to allow mosquitto custom conf

### DIFF
--- a/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -1,0 +1,5 @@
+# Add include_dir so Mosquitto can load custom configs if present
+do_install:append() {
+    sed -i 's|^#include_dir.*|include_dir /opt/persistent/mosquitto|' \
+        ${D}${sysconfdir}/mosquitto/mosquitto.conf
+}


### PR DESCRIPTION
Reason for change: DAB requirement for discovering device ID