### PR TITLE
RDKEMW-8441:  handle_ZERO_RETURN_as_closed_connection

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -278,7 +278,7 @@ PACKAGE_ARCH:pn-glibc-locale = "${OSS_LAYER_ARCH}"
 PR:pn-glibc-mtrace = "r0"
 PACKAGE_ARCH:pn-glibc-mtrace = "${OSS_LAYER_ARCH}"
 
-PR:pn-glib-networking = "r1"
+PR:pn-glib-networking = "r2"
 PACKAGE_ARCH:pn-glib-networking = "${OSS_LAYER_ARCH}"
 
 PR:pn-openssh = "r0"

--- a/recipes-core/glib-networking/glib-networking/handle_ZERO_RETURN_as_closed_connection.patch
+++ b/recipes-core/glib-networking/glib-networking/handle_ZERO_RETURN_as_closed_connection.patch
@@ -1,0 +1,22 @@
+diff --git a/tls/openssl/gtlsconnection-openssl.c b/tls/openssl/gtlsconnection-openssl.c
+index 06356c5..6d5deac 100644
+--- a/tls/openssl/gtlsconnection-openssl.c
++++ b/tls/openssl/gtlsconnection-openssl.c
+@@ -135,7 +135,16 @@ end_openssl_io (GTlsConnectionOpenssl  *openssl,
+     }
+
+   if (err_code == SSL_ERROR_ZERO_RETURN)
+-    return G_TLS_CONNECTION_BASE_OK;
++    {
++      if (SSL_get_shutdown(ssl) != 0)
++        {
++          g_set_error_literal (error, G_IO_ERROR,
++                                     G_IO_ERROR_CONNECTION_CLOSED,
++                                     _("Connection terminated unexpectedly"));
++          return G_TLS_CONNECTION_BASE_ERROR;
++        }
++      return G_TLS_CONNECTION_BASE_OK;
++    }
+
+   if (status == G_TLS_CONNECTION_BASE_OK ||
+       status == G_TLS_CONNECTION_BASE_WOULD_BLOCK ||

--- a/recipes-core/glib-networking/glib-networking_2.72.%.bbappend
+++ b/recipes-core/glib-networking/glib-networking_2.72.%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += "\
     file://force_tls1_2.patch \
     file://0001-Add-support-for-PKCS-12-encrypted-files.patch \
     file://0001-XRE-14265-request-client-cert-support.patch \
+    file://handle_ZERO_RETURN_as_closed_connection.patch \
 "
 
 PROVIDES += "glib-openssl"


### PR DESCRIPTION
Reason for change: The server sends close_notify right after TLS handshake while client still does an write operation which causes an infinite loop
Test Procedure: As per ticket description
Risks: Medium

Signed-off-by: Vigneshwaran33 vigneshwaranr333@gmail.com