### PR TITLE
RDKE-921: Clean up the mitigation done for dnsmasq restart in Xumo TV Release

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -694,7 +694,7 @@ PACKAGE_ARCH:pn-netbase = "${OSS_LAYER_ARCH}"
 PR:pn-nettle = "r1"
 PACKAGE_ARCH:pn-nettle = "${OSS_LAYER_ARCH}"
 
-PR:pn-networkmanager = "r10"
+PR:pn-networkmanager = "r11"
 PACKAGE_ARCH:pn-networkmanager = "${OSS_LAYER_ARCH}"
 
 PR:pn-nghttp2 = "r1"

--- a/recipes-connectivity/networkmanager/networkmanager/NM_dynamicDNS.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM_dynamicDNS.patch
@@ -2,12 +2,11 @@ Index: NetworkManager-1.43.7/src/core/dnsmasq/nm-dnsmasq-manager.c
 ===================================================================
 --- NetworkManager-1.43.7.orig/src/core/dnsmasq/nm-dnsmasq-manager.c
 +++ NetworkManager-1.43.7/src/core/dnsmasq/nm-dnsmasq-manager.c
-@@ -136,7 +136,7 @@ create_dm_cmd_line(const char
+@@ -136,7 +136,6 @@ create_dm_cmd_line(const char
 
      nm_strv_ptrarray_add_string_dup(cmd, "--no-hosts");
      nm_strv_ptrarray_add_string_dup(cmd, "--keep-in-foreground");
 -    nm_strv_ptrarray_add_string_dup(cmd, "--bind-interfaces");
-+    nm_strv_ptrarray_add_string_dup(cmd, "--bind-dynamic");
      nm_strv_ptrarray_add_string_dup(cmd, "--except-interface=lo");
      nm_strv_ptrarray_add_string_dup(cmd, "--clear-on-reload");
 
@@ -15,12 +14,11 @@ Index: NetworkManager-1.43.7/src/core/dns/nm-dns-dnsmasq.c
 ===================================================================
 --- NetworkManager-1.43.7.orig/src/core/dns/nm-dns-dnsmasq.c
 +++ NetworkManager-1.43.7/src/core/dns/nm-dns-dnsmasq.c
-@@ -521,7 +521,7 @@ _gl_pid_spawn_next_step(void)
+@@ -521,7 +521,6 @@ _gl_pid_spawn_next_step(void)
      argv[argv_idx++] = "--no-resolv"; /* Use only commandline */
      argv[argv_idx++] = "--keep-in-foreground";
      argv[argv_idx++] = "--no-hosts"; /* don't use /etc/hosts to resolve */
 -    argv[argv_idx++] = "--bind-interfaces";
-+    argv[argv_idx++] = "--bind-dynamic";
      argv[argv_idx++] = "--pid-file=" PIDFILE;
      argv[argv_idx++] = "--listen-address=127.0.0.1"; /* Should work for both 4 and 6 */
      argv[argv_idx++] = "--cache-size=400";

--- a/recipes-connectivity/networkmanager/networkmanager/NM_dynamicDNS.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/NM_dynamicDNS.patch
@@ -1,0 +1,26 @@
+Index: NetworkManager-1.43.7/src/core/dnsmasq/nm-dnsmasq-manager.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/dnsmasq/nm-dnsmasq-manager.c
++++ NetworkManager-1.43.7/src/core/dnsmasq/nm-dnsmasq-manager.c
+@@ -136,7 +136,7 @@ create_dm_cmd_line(const char
+
+     nm_strv_ptrarray_add_string_dup(cmd, "--no-hosts");
+     nm_strv_ptrarray_add_string_dup(cmd, "--keep-in-foreground");
+-    nm_strv_ptrarray_add_string_dup(cmd, "--bind-interfaces");
++    nm_strv_ptrarray_add_string_dup(cmd, "--bind-dynamic");
+     nm_strv_ptrarray_add_string_dup(cmd, "--except-interface=lo");
+     nm_strv_ptrarray_add_string_dup(cmd, "--clear-on-reload");
+
+Index: NetworkManager-1.43.7/src/core/dns/nm-dns-dnsmasq.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/dns/nm-dns-dnsmasq.c
++++ NetworkManager-1.43.7/src/core/dns/nm-dns-dnsmasq.c
+@@ -521,7 +521,7 @@ _gl_pid_spawn_next_step(void)
+     argv[argv_idx++] = "--no-resolv"; /* Use only commandline */
+     argv[argv_idx++] = "--keep-in-foreground";
+     argv[argv_idx++] = "--no-hosts"; /* don't use /etc/hosts to resolve */
+-    argv[argv_idx++] = "--bind-interfaces";
++    argv[argv_idx++] = "--bind-dynamic";
+     argv[argv_idx++] = "--pid-file=" PIDFILE;
+     argv[argv_idx++] = "--listen-address=127.0.0.1"; /* Should work for both 4 and 6 */
+     argv[argv_idx++] = "--cache-size=400";

--- a/recipes-connectivity/networkmanager/networkmanager/dnsmasq-logging.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/dnsmasq-logging.conf
@@ -1,2 +1,3 @@
 log-facility=/opt/logs/dnsmasq.log
 log-async
+bind-dynamic

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -33,6 +33,7 @@ SRC_URI = " \
     file://0001-wifi-don-t-recheck-auto-activate-on-disposal.patch \
     file://dnsmasq-logging.conf \
     file://NM_autoconnect_retry.patch \
+    file://file://NM_dynamicDNS.patch \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -33,7 +33,7 @@ SRC_URI = " \
     file://0001-wifi-don-t-recheck-auto-activate-on-disposal.patch \
     file://dnsmasq-logging.conf \
     file://NM_autoconnect_retry.patch \
-    file://file://NM_dynamicDNS.patch \
+    file://NM_dynamicDNS.patch \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"


### PR DESCRIPTION
Reason for change: dnsmasq should be able to recognize interfaces as and when they come up. Having bind-interfaces prevents dnsmasq from listening on interfaces which are up after it has started.
With this change, we make dnsmasq dynamically bind to interfaces as they come up.

Test Procedure: Build RDKE image and check connectivity scenarios.
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)