### PR TITLE
RDKOSS-490: Define OSS_LAYER_VERSION in reference layer

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -17,6 +17,8 @@ def get_oss_arch(d):
     arch += "-oss"
     return arch
 
+OSS_LAYER_VERSION = "4.8.0"
+
 LAYER_EXTENSION ?= ""
 OSS_LAYER_ARCH = "${@get_oss_arch(d)}${LAYER_EXTENSION}"
 PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"


### PR DESCRIPTION
Reason for the change - The meta-oss-reference-release repository has been excluded from the manifest to support the new OSS consumption model. Consequently, the OSS_LAYER_VERSION parameter previously defined in that repository is no longer available to the build.
To address this, the OSS_LAYER_VERSION parameter has been moved to the reference layer to ensure continued availability during the build process.