### PR TITLE
RDKEMW-9233: Network Process crash with Xumo Play

### DIFF
--- a/recipes-support/libsoup/files/0004-fix-heap-use-after-free-caused-by-Finishing-Queue-item-twice.patch
+++ b/recipes-support/libsoup/files/0004-fix-heap-use-after-free-caused-by-Finishing-Queue-item-twice.patch
@@ -1,0 +1,28 @@
+From 9778371197b4b6ada3387d767875a6721a8a6335 Mon Sep 17 00:00:00 2001
+From: Eugene Mutavchi <Ievgen_Mutavchi@comcast.com>
+Date: Fri, 10 Oct 2025 16:24:27 +0000
+Subject: [PATCH] fix 'heap-use-after-free' caused by 'finishing' queue item
+ twice
+
+---
+ libsoup/soup-session.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libsoup/soup-session.c b/libsoup/soup-session.c
+index c5694d2c..4e6b478b 100644
+--- a/libsoup/soup-session.c
++++ b/libsoup/soup-session.c
+@@ -2894,8 +2894,10 @@ run_until_read_done (SoupMessage          *msg,
+ 		if (soup_message_io_in_progress (msg))
+ 			soup_message_io_finished (msg);
+ 		item->paused = FALSE;
+-		item->state = SOUP_MESSAGE_FINISHING;
+-		soup_session_process_queue_item (item->session, item, FALSE);
++		if (item->state != SOUP_MESSAGE_FINISHED) {
++			item->state = SOUP_MESSAGE_FINISHING;
++			soup_session_process_queue_item (item->session, item, FALSE);
++		}
+ 	}
+ 	async_send_request_return_result (item, NULL, error);
+         soup_message_queue_item_unref (item);
+--

--- a/recipes-support/libsoup/libsoup_3.6.5.bb
+++ b/recipes-support/libsoup/libsoup_3.6.5.bb
@@ -15,6 +15,7 @@ SRC_URI = "${GNOME_MIRROR}/libsoup/${SHRT_VER}/libsoup-${PV}.tar.xz"
 SRC_URI[sha256sum] = "6891765aac3e949017945c3eaebd8cc8216df772456dc9f460976fbdb7ada234"
 
 SRC_URI += "file://comcast-RDK-56000-Cookie-size-limit-log_3.0.patch"
+SRC_URI += "file://0004-fix-heap-use-after-free-caused-by-Finishing-Queue-item-twice.patch"
 
 PROVIDES = "libsoup-3.0"
 CVE_PRODUCT = "libsoup"


### PR DESCRIPTION
RDKEMW-9233: Network Process crash with Xumo Play
Reason for change: soup_message_io_finished (called from run_until_read_done) invokes message_completed callback that 'finishes' the item.

Repeating the finishing steps in run_until_read_done results in a double-free error (or heap-use-after-free reported by ASAN). This happens when http2 io resolves run_until_read_async task(g_task_return_boolean (task, TRUE)) with the completion callback scheduled for the next cycle (see g_task_return -> complete_in_idle_cb). And, at the same time, the web page cancels (aborts) the read just before the task completion gets dispatched. In this scenario, http2 io went through the successful code path (and did not finish the io), while run_until_read_done gets the 'Operation was cancelled' error. Then, run_until_read_done calls soup_message_io_finished and tries to finish the item. This results in SoupMessageQueueItem being removed from the queue twice:

Upstream:
https://gitlab.gnome.org/GNOME/libsoup/-/merge_requests/481/ Test Procedure: Launch Xumo Play and check Network process crash Risks: Low
Priority: P1