### PR TITLE
RDKBACCL-1157 : Unsupported License packages in scarthgap

### DIFF
--- a/recipes-devtools/python/python3_3.12.9.bbappend
+++ b/recipes-devtools/python/python3_3.12.9.bbappend
@@ -1,10 +1,8 @@
-#PROVIDES += " gdbm-compat"
-#RPROVIDES:${PN} +=  " libgdbm_compat.so.4()(64bit)"
+# Disable gdbm for both target and native builds
+PACKAGECONFIG:remove = "gdbm"
+PACKAGECONFIG:remove:class-native = "gdbm"
 
-RDEPENDS:${PN} += "gdbm-compat"
-RDEPENDS:python3-db += "gdbm-compat"
-
-#PACKAGES += "libgdbm-compat"
-FILES:libgdbm-compat = "${libdir}/libgdbm_compat.so.*"
-
-#INSANE_SKIP:python3-db += "file-rdeps"
+# Remove the gdbm subpackage (which would expect _dbm.so)
+PACKAGES:remove = "${PN}-gdbm"
+FILES:${PN}-gdbm = ""
+RDEPENDS:${PN}-gdbm = ""


### PR DESCRIPTION
Reason for change: build issue is observed for python3_3.12 after backporting the gdbm
Test Procedure: bitbake python3
Risks: Low