### PR TITLE
RDKOSS-387: Enable uninative

### DIFF
--- a/conf/include/oss-config.inc
+++ b/conf/include/oss-config.inc
@@ -23,6 +23,10 @@ require license_flags_accepted.inc
 #Fix RDK-48310 & RDK-48267
 INCOMPATIBLE_LICENSE_EXCEPTIONS += "${@bb.utils.contains('DISTRO_FEATURES','build_gplv3', '${MLPREFIX}tar:GPL-3.0-only ${MLPREFIX}gdbserver:GPL-3.0-only ${MLPREFIX}gdbserver:LGPL-3.0-only ${MLPREFIX}gdb:GPL-3.0-only ${MLPREFIX} gdb:LGPL-3.0-only ${MLPREFIX}binutils:GPL-3.0-only ${MLPREFIX}libbfd:GPL-3.0-only', '', d)}"
 
+#Enable uninative 
+INHERIT:append = " uninative"
+include  conf/distro/include/yocto-uninative.inc
+
 require package_revisions_oss.inc
 BBMASK .= "|${RDKROOT}/rdke/common/meta-rdk-oss-reference/recipes-connectivity/bluez5/bluez5_5.77*"
 

--- a/conf/include/oss-config.inc
+++ b/conf/include/oss-config.inc
@@ -23,9 +23,9 @@ require license_flags_accepted.inc
 #Fix RDK-48310 & RDK-48267
 INCOMPATIBLE_LICENSE_EXCEPTIONS += "${@bb.utils.contains('DISTRO_FEATURES','build_gplv3', '${MLPREFIX}tar:GPL-3.0-only ${MLPREFIX}gdbserver:GPL-3.0-only ${MLPREFIX}gdbserver:LGPL-3.0-only ${MLPREFIX}gdb:GPL-3.0-only ${MLPREFIX} gdb:LGPL-3.0-only ${MLPREFIX}binutils:GPL-3.0-only ${MLPREFIX}libbfd:GPL-3.0-only', '', d)}"
 
-#Enable uninative 
+#Enable uninative
 INHERIT:append = " uninative"
-include  conf/distro/include/yocto-uninative.inc
+include conf/distro/include/yocto-uninative.inc
 
 require package_revisions_oss.inc
 BBMASK .= "|${RDKROOT}/rdke/common/meta-rdk-oss-reference/recipes-connectivity/bluez5/bluez5_5.77*"


### PR DESCRIPTION
Reason for the change:
The uninative helps to reduce dependency on the host system’s libraries when building native tools (like gcc, binutils, etc.) for the build process. Normally, native tools built during Yocto builds link against libraries from your host OS (e.g., glibc). This can cause incompatibility if you move your build artifacts to another machine with different library versions.