### PR TITLE
RDKBACCL-1237 : do_rootfs issue is seen for rdk-generic-broadband-image

### DIFF
--- a/recipes-common/lighttpd/files/drop_root_lighttpd.patch
+++ b/recipes-common/lighttpd/files/drop_root_lighttpd.patch
@@ -4,10 +4,10 @@ Source: COMCAST
 Subject: Drop root privileges for lighttpd process
 Signed-off-by: mkrish802 <Manoj_Krishnan@comcast.com>
 Upstream-Status: Pending
-Index: ssaman560/BPI-4.2/build-img/tmp/work/cortexa53-rdk-linux/lighttpd/1.4.74/lighttpd-1.4.74/src/server.c
+Index: lighttpd-1.4.74/src/server.c
 ===================================================================
---- ssaman560.orig/BPI-4.2/build-img/tmp/work/cortexa53-rdk-linux/lighttpd/1.4.74/lighttpd-1.4.74/src/server.c
-+++ ssaman560/BPI-4.2/build-img/tmp/work/cortexa53-rdk-linux/lighttpd/1.4.74/lighttpd-1.4.74/src/server.c
+--- lighttpd-1.4.74.orig/src/server.c
++++ lighttpd-1.4.74/src/server.c
 @@ -18,6 +18,7 @@
  #include "network_write.h"  /* network_write_show_handlers() */
  #include "reqpool.h"        /* request_pool_init() request_pool_free() */

--- a/recipes-common/lighttpd/lighttpd_1.4.74.bbappend
+++ b/recipes-common/lighttpd/lighttpd_1.4.74.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS:${PN}:remove = "lighttpd-module-fastcgi"
+RDEPENDS:${PN}:remove = "lighttpd-module-alias"

--- a/recipes-core/busybox/busybox/0001-add-ENABLE_FEATURE_SYSTEMD-and-use-it-in-syslogd.patch
+++ b/recipes-core/busybox/busybox/0001-add-ENABLE_FEATURE_SYSTEMD-and-use-it-in-syslogd.patch
@@ -4,6 +4,7 @@ Subject: [PATCH] add ENABLE_FEATURE_SYSTEMD and use it in syslogd
 Source: 9b3b9790b32d440eb89af5edda70a66b1829e861 Mon Sep 17 00:00:00 2001
 Signed-off-by: Davide Cavalca <davide@geexbox.org>
 Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+Upstream-Status: Pending
 ---
  include/libbb.h         |  6 ++++
  libbb/systemd_support.c | 62 +++++++++++++++++++++++++++++++++++++++++

--- a/recipes-core/busybox/busybox/busybox-1.31-ping-mdev-support.patch
+++ b/recipes-core/busybox/busybox/busybox-1.31-ping-mdev-support.patch
@@ -3,6 +3,7 @@ From: schall488 <shivabhaskar_challa@comcast.com>
 Subject: add missing patch of ping mdev support
 Source: COMCAST
 Signed-off-by: schall488 <shivabhaskar_challa@comcast.com>
+Upstream-Status: Pending
 Index: busybox-1.36.1/networking/ping.c
 ===================================================================
 --- busybox-1.36.1.orig/networking/ping.c

--- a/recipes-devtools/perl/perl_%.bbappend
+++ b/recipes-devtools/perl/perl_%.bbappend
@@ -1,0 +1,30 @@
+ALTERNATIVE:${PN}-misc:remove = " corelist cpan enc2xs encguess h2ph h2xs instmodsh json_pp libnetcfg \
+                     piconv pl2pm pod2html pod2man pod2text pod2usage podchecker podselect \
+                     prove ptar ptardiff ptargrep shasum splain xsubpp zipdetails"
+
+FILES:${PN}:remove = " ${bindir}/perl ${bindir}/pcorelist ${bindir}/pcpan ${bindir}/enc2xs ${bindir}/encguess ${bindir}/h2ph ${bindir}/h2xs ${bindir}/instmodsh ${bindir}/json_pp ${bindir}/libnetcfg \
+                     ${bindir}/piconv ${bindir}/pl2pm ${bindir}/pod2html ${bindir}/pod2man ${bindir}/pod2text ${bindir}/pod2usage ${bindir}/podchecker ${bindir}/podselect \
+                     ${bindir}/prove ${bindir}/ptar ${bindir}/ptardiff ${bindir}/ptargrep ${bindir}/shasum ${bindir}/splain ${bindir}/xsubpp ${bindir}/zipdetails \
+                     ${libdir}/perl5/site_perl ${libdir}/perl5/config.sh ${libdir}/perl5/${PV}/strict.pm ${libdir}/perl5/${PV}/warnings.pm \
+                     ${libdir}/perl5/${PV}/warnings ${libdir}/perl5/${PV}/vars.pm ${libdir}/perl5/site_perl ${libdir}/perl5/${PV}/ExtUtils/MANIFEST.SKIP \
+                     ${libdir}/perl5/${PV}/ExtUtils/xsubpp ${libdir}/perl5/${PV}/ExtUtils/typemap"
+
+PACKAGE_PREPROCESS_FUNCS:remove = " perl_package_preprocess"
+PACKAGE_PREPROCESS_FUNCS:append = " perl_package_preprocess_reduced"
+perl_package_preprocess_reduced () {
+        # Fix up installed configuration
+        sed -i -e "s,${D},,g" \
+               -e "s,${DEBUG_PREFIX_MAP},,g" \
+               -e "s,--sysroot=${STAGING_DIR_HOST},,g" \
+               -e "s,-isystem${STAGING_INCDIR} ,,g" \
+               -e "s,${STAGING_LIBDIR},${libdir},g" \
+               -e "s,${STAGING_BINDIR},${bindir},g" \
+               -e "s,${STAGING_INCDIR},${includedir},g" \
+               -e "s,${STAGING_BINDIR_NATIVE}/perl-native/,${bindir}/,g" \
+               -e "s,${STAGING_BINDIR_NATIVE}/,,g" \
+               -e "s,${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX},${bindir},g" \
+               -e 's:${RECIPE_SYSROOT}::g' \
+            ${PKGD}${libdir}/perl5/${PV}/${TARGET_ARCH}-linux/Config.pod \
+            ${PKGD}${libdir}/perl5/${PV}/${TARGET_ARCH}-linux/Config_git.pl \
+            ${PKGD}${libdir}/perl5/${PV}/${TARGET_ARCH}-linux/Config_heavy.pl
+}


### PR DESCRIPTION
Reason for change : some modules are not explicitly defined for newer version of lightppd
Test Procedure : bitbake rdk-generic-broadband-image should not throw nothing provides lighttpd-module-fastcgi Risks: None