### PR TITLE
RDKEMW-7910: Reduce opkg install thread count from 64 to 16

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -718,7 +718,7 @@ PACKAGE_ARCH:pn-openssl ?= "${OSS_LAYER_ARCH}"
 PR:pn-openssl-1.1.1l ?= "r0"
 PACKAGE_ARCH:pn-openssl-1.1.1l ?= "${OSS_LAYER_ARCH}"
 
-PR:pn-opkg ?= "r1"
+PR:pn-opkg ?= "r2"
 PACKAGE_ARCH:pn-opkg ?= "${OSS_LAYER_ARCH}"
 
 PR:pn-opkg-arch-config ?= "r1"

--- a/recipes-devtools/opkg/opkg/multi_thread_installer.patch
+++ b/recipes-devtools/opkg/opkg/multi_thread_installer.patch
@@ -42,7 +42,7 @@ index d442d3d..298d9c7 100644
 +       gErr = err;
 +    }
 +}
-+#define NUM_THREADS 64
++#define NUM_THREADS 16
 +
  static int libsolv_solver_execute_transaction(libsolv_solver_t *libsolv_solver)
  {


### PR DESCRIPTION
Reason for change: Limit max parallel threads to 16 during opkg install to avoid build failures
Test procedure: Build shouldn't fail during opkg install
Risks: Low