### PR TITLE
RDKEMW-10656: Move SRCREV, PV, PR to individual recipes

### DIFF
--- a/recipes-extended/rdkperf/rdkperf_git.bb
+++ b/recipes-extended/rdkperf/rdkperf_git.bb
@@ -27,6 +27,7 @@ SRC_URI = "git://github.com/rdkcentral/rdkperf;protocol=git;branch=main"
 
 SRCREV = "d802d561c4a2a4456403d572da75e73032d48d91"
 
+
 PV = "1.0.0+git${SRCPV}"
 PR ?= "r0"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
RDKEMW-10656: Move SRCREV, PV, PR to individual recipes

Reason for change: move recipe information closer to developer’s repos
Test Procedure: see Jira ticket
Risks: Low
Priority: P1