### PR TITLE
RDK-59422: Provide Build to test with dns64 Proxy enabled

### DIFF
--- a/recipes-connectivity/bind/files/named.conf.options
+++ b/recipes-connectivity/bind/files/named.conf.options
@@ -1,16 +1,18 @@
 options {
-         directory "/var/cache/bind";
-         forwarders {
-                     //OPT
-         };
-         forward only;
-         max-udp-size 600;
-         listen-on { 127.0.0.1; };
-         listen-on-v6 { ::1; };
-         # option below is to eliminate Additional NS records in responding to a request from libc-api.
-         # When we start using DNSSEC we will have to revist this option.
-         minimal-responses yes;
-         auth-nxdomain no;    # conform to RFC1035
-         //DNS64
+        directory "/var/cache/bind";
+        forwarders {
+                //eth0
+                //wlan0
+        };
+
+        forward only;
+        max-udp-size 600;
+        listen-on { 127.0.0.1; };
+        listen-on-v6 { ::1; };
+        # option below is to eliminate Additional NS records in responding to a request from libc-api.
+        # When we start using DNSSEC we will have to revist this option.
+        minimal-responses yes;
+        auth-nxdomain no;    # conform to RFC1035
+        //DNS64
 };
 

--- a/recipes-connectivity/bind/files/update_namedoptions.sh
+++ b/recipes-connectivity/bind/files/update_namedoptions.sh
@@ -18,26 +18,31 @@
 # limitations under the License.
 ##############################################################################
 if [ -f /etc/device.properties ];then
-     . /etc/device.properties
+    . /etc/device.properties
 fi
 if [ -f /lib/rdk/t2Shared_api.sh ]; then
     source /lib/rdk/t2Shared_api.sh
 fi
+
+# Parse command line arguments
+ACTION=$1
+INTERFACE=$2
+shift 2
 DNS_SERVERS=$*
+
 LOG_FILE="/opt/logs/named.log"
-echo "`/bin/timestamp` Input parameters: $DNS_SERVERS" >> $LOG_FILE
+BUILD_CONF_PATH="/etc/bind/named.conf.options"
+SCRIPT_NAME="update_namedoptions.sh"
+
+echo "`/bin/timestamp` [$SCRIPT_NAME] Action: $ACTION, Interface: $INTERFACE, DNS Servers: $DNS_SERVERS" >> $LOG_FILE
+
+if [ "x$ACTION" != "xadd" ] && [ "x$ACTION" != "xremove" ]; then
+    echo "`/bin/timestamp` [$SCRIPT_NAME] ERROR: Invalid action '$ACTION'. Must be 'add' or 'remove'" >> $LOG_FILE
+    exit 1
+fi
+
 DNS64_SERVER1=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server1 2>&1`
-if [ "x$DNS64_SERVER1" = "x" ]; then
-    DNS64_SERVER1="2a00:1098:2b::1" # nat64.net	Amsterdam
-    echo "`/bin/timestamp` DNS64 Server1 not configured, using default: $DNS64_SERVER1" >> $LOG_FILE
-fi
-
 DNS64_SERVER2=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server2 2>&1`
-if [ "x$DNS64_SERVER2" = "x" ]; then
-    DNS64_SERVER2="2a01:4ff:f0:9876::1" # nat64.net	Ashburn
-    echo "`/bin/timestamp` DNS64 Server2 not configured, using default: $DNS64_SERVER2" >> $LOG_FILE
-fi
-
 DNS64_SERVER3=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server3 2>&1`
 DNS64_SERVER4=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server4 2>&1`
 
@@ -49,52 +54,85 @@ APPENDER_STR="{ \n clients { any; };\n exclude { 64:FF9B::/96; ::ffff:0000:0000/
 DNS64_STR=""
 if [ "x$DNS64_SERVER1" != "x" ]; then
     DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER1 $APPENDER_STR"
-    echo "`/bin/timestamp` DNS64 Proxy Server1: $DNS64_SERVER1" >> $LOG_FILE
+    echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Proxy Server1: $DNS64_SERVER1" >> $LOG_FILE
 fi
 if [ "x$DNS64_SERVER2" != "x" ]; then
     DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER2 $APPENDER_STR"
-    echo "`/bin/timestamp` DNS64 Proxy Server2: $DNS64_SERVER2" >> $LOG_FILE
+    echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Proxy Server2: $DNS64_SERVER2" >> $LOG_FILE
 fi
 if [ "x$DNS64_SERVER3" != "x" ]; then
     DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER3 $APPENDER_STR"
-    echo "`/bin/timestamp` DNS64 Proxy Server3: $DNS64_SERVER3" >> $LOG_FILE
+    echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Proxy Server3: $DNS64_SERVER3" >> $LOG_FILE
 fi
 if [ "x$DNS64_SERVER4" != "x" ]; then
     DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER4 $APPENDER_STR"
-    echo "`/bin/timestamp` DNS64 Proxy Server4: $DNS64_SERVER4" >> $LOG_FILE
+    echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Proxy Server4: $DNS64_SERVER4" >> $LOG_FILE
 fi
 
 if [ "x$DNS64_STR" = "x" ]; then
-    echo "`/bin/timestamp` No DNS64 Proxy servers configured" >> $LOG_FILE
+    echo "`/bin/timestamp` [$SCRIPT_NAME] No DNS64 Proxy servers configured" >> $LOG_FILE
 fi
 
 if [ "x$RFC_BIND_ENABLED" = "xtrue" ]; then
-	BUILD_CONF_PATH="/tmp/named.conf.options"
-	# Refresh the options again. Since resolver config can change while box is running.
-	# Added the following to handle that case.
-	/bin/umount /etc/bind/named.conf.options
-	rm -f $BUILD_CONF_PATH
-	/sbin/mount-copybind  $BUILD_CONF_PATH /etc/bind/named.conf.options
-	sed -i "s#\/\/OPT#$DNS_SERVERS#g" $BUILD_CONF_PATH
-	if [ "x$DNS64_STR" != "x" ];  then
-		sed -i "s#\/\/DNS64#$DNS64_STR#g" $BUILD_CONF_PATH
-		echo "DNS64 Servers are Configured" >>$LOG_FILE
-	else
-		echo "DNS64 Servers not Configured" >>$LOG_FILE
+
+    # Refresh the options again. Since resolver config can change while box is running.
+    # Added the following to handle that case.
+
+    if [ "$ACTION" = "remove" ]; then
+        # Remove DNS servers for the specified interface
+        if [ "$INTERFACE" = "eth0" ]; then
+            sed -i '/\/\/eth0/,/\/\/wlan0/c\ \t\t//eth0\n\t\t//wlan0' $BUILD_CONF_PATH
+            echo "`/bin/timestamp` [$SCRIPT_NAME] Removed DNS servers for eth0" >> $LOG_FILE
+        else
+            sed -i '/\/\/wlan0/,/\};/c\ \t\t//wlan0\n\t};' $BUILD_CONF_PATH
+            echo "`/bin/timestamp` [$SCRIPT_NAME] Removed DNS servers for wlan0" >> $LOG_FILE
+        fi
+    elif [ "$ACTION" = "add" ]; then
+        # Add DNS servers for the specified interface
+        if [ "x$DNS_SERVERS" = "x" ]; then
+            echo "`/bin/timestamp` [$SCRIPT_NAME] ERROR: No DNS servers provided for add action" >> $LOG_FILE
+            exit 1
+        fi
+
+        # Add DNS servers one by one if not present
+        for DNS in $DNS_SERVERS; do
+            # Skip empty entries
+            if [ "x$DNS" = "x" ]; then
+                continue
+            fi
+
+            if grep -q "$DNS" $BUILD_CONF_PATH; then
+                echo "`/bin/timestamp` [$SCRIPT_NAME] DNS server $DNS already present, skipping" >> $LOG_FILE
+            else
+                if [ "$INTERFACE" = "eth0" ]; then
+                    sed -i "/\/\/eth0/a\ \t\t$DNS;" $BUILD_CONF_PATH
+                else
+                    sed -i "/\/\/wlan0/a\ \t\t$DNS;" $BUILD_CONF_PATH
+                fi
+                echo "`/bin/timestamp` [$SCRIPT_NAME] Added DNS server $DNS for $INTERFACE" >> $LOG_FILE
+            fi
+        done
     fi
-    cat /tmp/named.conf.options >/etc/bind/named.conf.options
+
+    if [ "x$DNS64_STR" != "x" ];  then
+        sed -i "s#\/\/DNS64#$DNS64_STR#g" $BUILD_CONF_PATH
+        echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Servers are Configured" >>$LOG_FILE
+    else
+        echo "`/bin/timestamp` [$SCRIPT_NAME] DNS64 Servers not Configured, Empty" >>$LOG_FILE
+    fi
+
     if [ -f /usr/sbin/named -o -f /media/apps/bind-dl/usr/sbin/named ];then
         pkill -HUP named
         systemctl restart named.service
-        echo "`/bin/timestamp` Bind Support is enabled, named is used for  DNS Resolutions." >> $LOG_FILE
+        echo "`/bin/timestamp` [$SCRIPT_NAME] Bind Support is enabled, named is used for  DNS Resolutions." >> $LOG_FILE
         if [ -f /lib/rdk/logMilestone.sh ]; then
             sh /lib/rdk/logMilestone.sh "NAMED_STARTED"
         fi
     else
-        echo "`/bin/timestamp` Bind Support is enabled, named binary is not present, dns will fail" >> $LOG_FILE
+        echo "`/bin/timestamp` [$SCRIPT_NAME] Bind Support is enabled, named binary is not present, dns will fail" >> $LOG_FILE
     fi
 else
-	# This is to make sure atleast dnsmasq runs even if it fails initially. or some switch happened inbetween.
-	echo "`/bin/timestamp` Bind Support is not enabled" >> $LOG_FILE
-	systemctl stop named.service
+    # This is to make sure atleast dnsmasq runs even if it fails initially. or some switch happened inbetween.
+    echo "`/bin/timestamp` [$SCRIPT_NAME] Bind Support is not enabled" >> $LOG_FILE
+    systemctl stop named.service
 fi

--- a/recipes-connectivity/bind/files/update_namedoptions.sh
+++ b/recipes-connectivity/bind/files/update_namedoptions.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+if [ -f /etc/device.properties ];then
+     . /etc/device.properties
+fi
+if [ -f /lib/rdk/t2Shared_api.sh ]; then
+    source /lib/rdk/t2Shared_api.sh
+fi
+DNS_SERVERS=$*
+LOG_FILE="/opt/logs/named.log"
+echo "`/bin/timestamp` Input parameters: $DNS_SERVERS" >> $LOG_FILE
+DNS64_SERVER1=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server1 2>&1`
+if [ "x$DNS64_SERVER1" = "x" ]; then
+    DNS64_SERVER1="2a00:1098:2b::1" # nat64.net	Amsterdam
+    echo "`/bin/timestamp` DNS64 Server1 not configured, using default: $DNS64_SERVER1" >> $LOG_FILE
+fi
+
+DNS64_SERVER2=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server2 2>&1`
+if [ "x$DNS64_SERVER2" = "x" ]; then
+    DNS64_SERVER2="2a01:4ff:f0:9876::1" # nat64.net	Ashburn
+    echo "`/bin/timestamp` DNS64 Server2 not configured, using default: $DNS64_SERVER2" >> $LOG_FILE
+fi
+
+DNS64_SERVER3=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server3 2>&1`
+DNS64_SERVER4=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Server4 2>&1`
+
+RFC_BIND_ENABLED=`tr181 -g Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNS64Proxy.Enable 2>&1`
+if [ "x$RFC_BIND_ENABLED" = "x" ]; then
+    RFC_BIND_ENABLED="true"
+fi
+APPENDER_STR="{ \n clients { any; };\n exclude { 64:FF9B::/96; ::ffff:0000:0000/96; }; \n suffix ::; \n };"
+DNS64_STR=""
+if [ "x$DNS64_SERVER1" != "x" ]; then
+    DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER1 $APPENDER_STR"
+    echo "`/bin/timestamp` DNS64 Proxy Server1: $DNS64_SERVER1" >> $LOG_FILE
+fi
+if [ "x$DNS64_SERVER2" != "x" ]; then
+    DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER2 $APPENDER_STR"
+    echo "`/bin/timestamp` DNS64 Proxy Server2: $DNS64_SERVER2" >> $LOG_FILE
+fi
+if [ "x$DNS64_SERVER3" != "x" ]; then
+    DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER3 $APPENDER_STR"
+    echo "`/bin/timestamp` DNS64 Proxy Server3: $DNS64_SERVER3" >> $LOG_FILE
+fi
+if [ "x$DNS64_SERVER4" != "x" ]; then
+    DNS64_STR="$DNS64_STR \ndns64 $DNS64_SERVER4 $APPENDER_STR"
+    echo "`/bin/timestamp` DNS64 Proxy Server4: $DNS64_SERVER4" >> $LOG_FILE
+fi
+
+if [ "x$DNS64_STR" = "x" ]; then
+    echo "`/bin/timestamp` No DNS64 Proxy servers configured" >> $LOG_FILE
+fi
+
+if [ "x$RFC_BIND_ENABLED" = "xtrue" ]; then
+	BUILD_CONF_PATH="/tmp/named.conf.options"
+	# Refresh the options again. Since resolver config can change while box is running.
+	# Added the following to handle that case.
+	/bin/umount /etc/bind/named.conf.options
+	rm -f $BUILD_CONF_PATH
+	/sbin/mount-copybind  $BUILD_CONF_PATH /etc/bind/named.conf.options
+	sed -i "s#\/\/OPT#$DNS_SERVERS#g" $BUILD_CONF_PATH
+	if [ "x$DNS64_STR" != "x" ];  then
+		sed -i "s#\/\/DNS64#$DNS64_STR#g" $BUILD_CONF_PATH
+		echo "DNS64 Servers are Configured" >>$LOG_FILE
+	else
+		echo "DNS64 Servers not Configured" >>$LOG_FILE
+    fi
+    cat /tmp/named.conf.options >/etc/bind/named.conf.options
+    if [ -f /usr/sbin/named -o -f /media/apps/bind-dl/usr/sbin/named ];then
+        pkill -HUP named
+        systemctl restart named.service
+        echo "`/bin/timestamp` Bind Support is enabled, named is used for  DNS Resolutions." >> $LOG_FILE
+        if [ -f /lib/rdk/logMilestone.sh ]; then
+            sh /lib/rdk/logMilestone.sh "NAMED_STARTED"
+        fi
+    else
+        echo "`/bin/timestamp` Bind Support is enabled, named binary is not present, dns will fail" >> $LOG_FILE
+    fi
+else
+	# This is to make sure atleast dnsmasq runs even if it fails initially. or some switch happened inbetween.
+	echo "`/bin/timestamp` Bind Support is not enabled" >> $LOG_FILE
+	systemctl stop named.service
+fi

--- a/recipes-connectivity/networkmanager/networkmanager/99-update-named.sh
+++ b/recipes-connectivity/networkmanager/networkmanager/99-update-named.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+##############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+# NetworkManager dispatcher script to update BIND DNS64 configuration
+# This script is called by NetworkManager when network events occur
+#
+# Note: NetworkManager updates /var/run/NetworkManager/no-stub-resolv.conf
+# which is symlinked to /etc/resolv.dnsmasq
+
+INTERFACE=$1
+ACTION=$2
+LOG_FILE="/opt/logs/named.log"
+
+echo "`/bin/timestamp` nm-dispatcher: Interface=$INTERFACE Action=$ACTION" >> $LOG_FILE
+
+case "$ACTION" in
+    up|dhcp4-change|dhcp6-change)
+        # Check if resolv.dnsmasq exists and has DNS servers
+        if [ -f /etc/resolv.dnsmasq ] && [ -s /etc/resolv.dnsmasq ]; then
+            # Extract DNS servers with semicolons
+            DNS_ADDR=""
+            while read -r line; do
+                ADDR=$(echo $line | cut -d " " -f2)
+                if [ "$line" != "${line#*[0-9].[0-9]}" ]; then
+                    # IPv4
+                    DNS_ADDR="$DNS_ADDR $ADDR;"
+                    echo "`/bin/timestamp` nm-dispatcher: Found IPv4 DNS server: $ADDR" >> $LOG_FILE
+                elif [ "$line" != "${line#*:[0-9a-fA-F]}" ]; then
+                    # IPv6
+                    DNS_ADDR="$DNS_ADDR $ADDR;"
+                    echo "`/bin/timestamp` nm-dispatcher: Found IPv6 DNS server: $ADDR" >> $LOG_FILE
+                fi
+            done < /etc/resolv.dnsmasq
+
+            # Call update_namedoptions.sh with DNS servers
+            if [ -n "$DNS_ADDR" ]; then
+                if [ -f /lib/rdk/update_namedoptions.sh ]; then
+                    echo "`/bin/timestamp` nm-dispatcher: Updating BIND configuration with DNS servers: $DNS_ADDR" >> $LOG_FILE
+                    /bin/sh /lib/rdk/update_namedoptions.sh $DNS_ADDR
+                else
+                    echo "`/bin/timestamp` nm-dispatcher: ERROR - /lib/rdk/update_namedoptions.sh not found" >> $LOG_FILE
+                fi
+            fi
+        fi
+        ;;
+esac
+
+exit 0

--- a/recipes-connectivity/networkmanager/networkmanager/99-update-named.sh
+++ b/recipes-connectivity/networkmanager/networkmanager/99-update-named.sh
@@ -24,39 +24,63 @@
 # Note: NetworkManager updates /var/run/NetworkManager/no-stub-resolv.conf
 # which is symlinked to /etc/resolv.dnsmasq
 
+SCRIPT_NAME="[nm-dispatcher]"
 INTERFACE=$1
 ACTION=$2
 LOG_FILE="/opt/logs/named.log"
 
-echo "`/bin/timestamp` nm-dispatcher: Interface=$INTERFACE Action=$ACTION" >> $LOG_FILE
+echo "`/bin/timestamp` $SCRIPT_NAME: Interface=$INTERFACE Action=$ACTION" >> $LOG_FILE
+
+# Determine interface type (eth0 or wlan0)
+IFACE_TYPE=""
+case "$INTERFACE" in
+    eth*)
+        IFACE_TYPE="eth0"
+        ;;
+    wlan*)
+        IFACE_TYPE="wlan0"
+        ;;
+    *)
+        echo "`/bin/timestamp` $SCRIPT_NAME: named interface type: $INTERFACE" >> $LOG_FILE
+        exit 0
+        ;;
+esac
 
 case "$ACTION" in
     up|dhcp4-change|dhcp6-change)
         # Check if resolv.dnsmasq exists and has DNS servers
         if [ -f /etc/resolv.dnsmasq ] && [ -s /etc/resolv.dnsmasq ]; then
-            # Extract DNS servers with semicolons
             DNS_ADDR=""
             while read -r line; do
                 ADDR=$(echo $line | cut -d " " -f2)
                 if [ "$line" != "${line#*[0-9].[0-9]}" ]; then
                     # IPv4
-                    DNS_ADDR="$DNS_ADDR $ADDR;"
-                    echo "`/bin/timestamp` nm-dispatcher: Found IPv4 DNS server: $ADDR" >> $LOG_FILE
+                    DNS_ADDR="$DNS_ADDR $ADDR"
+                    echo "`/bin/timestamp` $SCRIPT_NAME: Found IPv4 DNS server: $ADDR" >> $LOG_FILE
                 elif [ "$line" != "${line#*:[0-9a-fA-F]}" ]; then
                     # IPv6
-                    DNS_ADDR="$DNS_ADDR $ADDR;"
-                    echo "`/bin/timestamp` nm-dispatcher: Found IPv6 DNS server: $ADDR" >> $LOG_FILE
+                    DNS_ADDR="$DNS_ADDR $ADDR"
+                    echo "`/bin/timestamp` $SCRIPT_NAME: Found IPv6 DNS server: $ADDR" >> $LOG_FILE
                 fi
             done < /etc/resolv.dnsmasq
 
-            # Call update_namedoptions.sh with DNS servers
-            if [ -n "$DNS_ADDR" ]; then
+            # Call update_namedoptions.sh with interface-specific DNS servers
+            if [ -n "$DNS_ADDR" ] && [ -n "$IFACE_TYPE" ]; then
                 if [ -f /lib/rdk/update_namedoptions.sh ]; then
-                    echo "`/bin/timestamp` nm-dispatcher: Updating BIND configuration with DNS servers: $DNS_ADDR" >> $LOG_FILE
-                    /bin/sh /lib/rdk/update_namedoptions.sh $DNS_ADDR
-                else
-                    echo "`/bin/timestamp` nm-dispatcher: ERROR - /lib/rdk/update_namedoptions.sh not found" >> $LOG_FILE
+                    echo "`/bin/timestamp` $SCRIPT_NAME: Adding DNS servers for $IFACE_TYPE: $DNS_ADDR" >> $LOG_FILE
+                    /bin/sh /lib/rdk/update_namedoptions.sh add $IFACE_TYPE $DNS_ADDR
                 fi
+            else
+                echo "`/bin/timestamp` $SCRIPT_NAME: No DNS servers found " >> $LOG_FILE
+            fi
+        fi
+        ;;
+    down)
+        # When interface goes down, remove its DNS servers
+        if [ -n "$IFACE_TYPE" ]; then
+            if [ -f /lib/rdk/update_namedoptions.sh ]; then
+                echo "`/bin/timestamp` $SCRIPT_NAME: Removing DNS servers for $IFACE_TYPE (interface down)" >> $LOG_FILE
+                /bin/sh /lib/rdk/update_namedoptions.sh remove $IFACE_TYPE
             fi
         fi
         ;;

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
@@ -1,7 +1,8 @@
 [main]
 plugins=ifupdown,keyfile
 autoconnect-retries-default=0
-dns=dnsmasq
+dns=none
+rc-manager=unmanaged
 
 [ifupdown]
 managed=true

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -33,6 +33,7 @@ SRC_URI = " \
     file://NM_dynamicDNS.patch \
     file://connectivity-check.patch \
     file://org.freedesktop.nm_connectivity.service \
+    file://99-update-named.sh \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"
@@ -69,7 +70,7 @@ CFLAGS:append:libc-musl = " \
 do_compile:prepend() {
     export GI_TYPELIB_PATH="${B}}/src/libnm-client-impl${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
 }
-PACKAGECONFIG ??= "readline nss ifupdown dnsmasq nmcli vala concheck \
+PACKAGECONFIG ??= "readline nss ifupdown bind nmcli vala concheck \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', bb.utils.contains('DISTRO_FEATURES', 'x11', 'consolekit', '', d), d)} \
     ${@bb.utils.filter('DISTRO_FEATURES', 'wifi polkit', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'selinux', 'selinux audit', '', d)} \
@@ -84,7 +85,7 @@ PACKAGECONFIG[polkit] = "-Dpolkit=true,-Dpolkit=false,polkit"
 #PACKAGECONFIG[consolekit] = "-Dsession_tracking_consolekit=true,-Dsession_tracking_consolekit=false,consolekit,consolekit"
 PACKAGECONFIG[modemmanager] = "-Dmodem_manager=true,-Dmodem_manager=false,modemmanager mobile-broadband-provider-info"
 PACKAGECONFIG[ppp] = "-Dppp=false -Dpppd=${sbindir}/pppd,-Dppp=false,ppp"
-PACKAGECONFIG[dnsmasq] = "-Ddnsmasq=${bindir}/dnsmasq"
+#PACKAGECONFIG[dnsmasq] = "-Ddnsmasq=${bindir}/dnsmasq"
 PACKAGECONFIG[nss] = "-Dcrypto=nss,,nss"
 #PACKAGECONFIG[resolvconf] = "-Dresolvconf=${base_sbindir}/resolvconf,-Dresolvconf=no,,resolvconf"
 PACKAGECONFIG[gnutls] = "-Dcrypto=gnutls,,gnutls"
@@ -224,7 +225,7 @@ RDEPENDS:${PN}-daemon += "\
 "
 RRECOMMENDS:${PN}-daemon += "\
     ${NETWORKMANAGER_FIREWALL_DEFAULT} \
-    ${@bb.utils.filter('PACKAGECONFIG', 'dnsmasq', d)} \
+    ${@bb.utils.filter('PACKAGECONFIG', 'bind', d)} \
 "
 INITSCRIPT_NAME:${PN}-daemon = "network-manager"
 SYSTEMD_SERVICE:${PN}-daemon = "\
@@ -250,12 +251,14 @@ do_install:append() {
     install -d ${D}${sysconfdir}
     install -d ${D}${sysconfdir}/NetworkManager/
     install -d ${D}${sysconfdir}/NetworkManager/conf.d/
-    install -d ${D}${sysconfdir}/NetworkManager/dnsmasq.d/
+    #install -d ${D}${sysconfdir}/NetworkManager/dnsmasq.d/
     install -d ${D}${datadir}/dbus-1/system-services
+    install -d ${D}${sysconfdir}/NetworkManager/dispatcher.d
     install ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/NetworkManager.conf
     install ${WORKDIR}/95-logging.conf ${D}${sysconfdir}/NetworkManager/conf.d/95-logging.conf
-    install ${WORKDIR}/dnsmasq-logging.conf ${D}${sysconfdir}/NetworkManager/dnsmasq.d/dnsmasq-logging.conf
-     install -m 0755 ${WORKDIR}/org.freedesktop.nm_connectivity.service ${D}${datadir}/dbus-1/system-services/
+    #install ${WORKDIR}/dnsmasq-logging.conf ${D}${sysconfdir}/NetworkManager/dnsmasq.d/dnsmasq-logging.conf
+    install -m 0755 ${WORKDIR}/org.freedesktop.nm_connectivity.service ${D}${datadir}/dbus-1/system-services/
+    install -m 0755 ${WORKDIR}/99-update-named.sh ${D}${sysconfdir}/NetworkManager/dispatcher.d/99-update-named.sh
 
     install -Dm 0755 ${WORKDIR}/${BPN}.initd ${D}${sysconfdir}/init.d/network-manager
 

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -252,7 +252,7 @@ RDEPENDS:${PN} += "\
      coreutils \
      crun \
      ctemplate \
-     dnsmasq \
+     bind \
      dosfstools \
      essos \
      fcgi \


### PR DESCRIPTION
RDK-59422: Provide Build to test with dns64 Proxy enabled
Reason for change : enable bind and remove dnsmasq dependency of networkmanager
Signed-off-by: Muhammed Rafi C <muhammed_rafi@comcast.com>