### PR TITLE
RDKBACCL-1315 : systemd services redirects output to file

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,5 +1,5 @@
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-           echo "export SYSTEMD_PAGER=/bin/cat" >> ${D}${sysconfdir}/profile
+           echo "export SYSTEMD_PAGER=" >> ${D}${sysconfdir}/profile
     fi
 }


### PR DESCRIPTION
Reason for change : disabling paging for smooth output in terminal Test Procedure : systemctl/jounalctl commands should print output on the terminal
Risks: None