### PR TITLE
RDKOSS-596:  Joy-Con controller detection in libmanette

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -453,7 +453,7 @@ PACKAGE_ARCH:pn-libinput ?= "${OSS_LAYER_ARCH}"
 PR:pn-libjpeg ?= "r0"
 PACKAGE_ARCH:pn-libjpeg ?= "${OSS_LAYER_ARCH}"
 
-PR:pn-libmanette ?= "r3"
+PR:pn-libmanette ?= "r4"
 PACKAGE_ARCH:pn-libmanette ?= "${OSS_LAYER_ARCH}"
 
 PR:pn-libmd ?= "r0"

--- a/recipes-extended/libmanette/libmanette/0001-nintendo-joycon-L-R-detect.patch
+++ b/recipes-extended/libmanette/libmanette/0001-nintendo-joycon-L-R-detect.patch
@@ -1,0 +1,39 @@
+From 793c69260ff49539a884c13d0a1b65236f6f4c27 Mon Sep 17 00:00:00 2001
+From: Ganesh prasad Sahu <GaneshPrasad_Sahu@comcast.com>
+Date: Thu, 15 May 2025 13:49:13 +0000
+Subject: [PATCH] nintendo joycon L/R detect
+
+---
+ src/manette-device.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/manette-device.c b/src/manette-device.c
+index b9b08a2..0fa5a00 100644
+--- a/src/manette-device.c
++++ b/src/manette-device.c
+@@ -211,16 +211,22 @@ is_game_controller (struct libevdev *device)
+   has_joystick_axes_or_buttons =
+     has_key (device, BTN_TRIGGER) ||
+     has_key (device, BTN_A) ||
++    has_key (device, BTN_Z) ||
+     has_key (device, BTN_1) ||
++    has_key (device, BTN_TR2) ||
++    has_key (device, BTN_TL2) ||
+     has_abs (device, ABS_RX) ||
+     has_abs (device, ABS_RY) ||
+     has_abs (device, ABS_RZ) ||
++    has_abs (device, ABS_X) ||
++    has_abs (device, ABS_Y) ||
+     has_abs (device, ABS_THROTTLE) ||
+     has_abs (device, ABS_RUDDER) ||
+     has_abs (device, ABS_WHEEL) ||
+     has_abs (device, ABS_GAS) ||
+     has_abs (device, ABS_BRAKE);
+ 
++  g_print("manet-debug: device: %s is gamecontroller=%s\n",libevdev_get_name (device), has_joystick_axes_or_buttons?"Y":"N" );
+   return has_joystick_axes_or_buttons;
+ }
+ 
+-- 
+2.25.1
+

--- a/recipes-extended/libmanette/libmanette/99-gamepad-set-attr.rules
+++ b/recipes-extended/libmanette/libmanette/99-gamepad-set-attr.rules
@@ -1,0 +1,2 @@
+#Add the attributes to set Joystick property for Joy-con controller
+SUBSYSTEM=="input", ATTRS{name}=="Joy-Con (R)", KERNEL=="event*", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_KEY}="1"

--- a/recipes-extended/libmanette/libmanette_0.2.6.bb
+++ b/recipes-extended/libmanette/libmanette_0.2.6.bb
@@ -13,6 +13,8 @@ SRC_URI = "https://download.gnome.org/sources/libmanette/0.2/libmanette-${PV}.ta
            file://0001-map-key-menu-back-as-btn.patch \
            file://0003-button-values-for-gas-brake.patch \
            file://0001-nintendo-digital-trigger-dpad-fix.patch \
+           file://0001-nintendo-joycon-L-R-detect.patch \
+           file://99-gamepad-set-attr.rules \
            "
 
 SRC_URI[sha256sum] = "63653259a821ec7d90d681e52e757e2219d462828c9d74b056a5f53267636bac"
@@ -23,6 +25,9 @@ PACKAGECONFIG:append = "wayland-inputfd"
 PACKAGECONFIG[wayland-inputfd] = "-Dwayland-inputfd=true,-Dwayland-inputfd=false,wayland wayland-native"
 
 do_install:append() {
+    install -d ${D}${sysconfdir}/udev
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/99-gamepad-set-attr.rules ${D}${sysconfdir}/udev/rules.d/99-gamepad-set-attr.rules
     install -d ${D}${datadir}/libmanette/
     cp -f ${WORKDIR}/gamecontrollerdb ${D}${datadir}/libmanette/
     chmod 0644 ${D}${datadir}/libmanette/gamecontrollerdb
@@ -32,6 +37,7 @@ do_install:append() {
 }
 
 FILES:${PN} += "${datadir}/libmanette/"
+FILES:${PN} += "${sysconfdir}/udev/"
 #FILES:${PN}-ptest =+ "${bindir}/manette-test"
 #FILES:${PN}-ptest =+ "${bindir}/ManetteEventMapping"
 #FILES:${PN}-ptest =+ "${bindir}/ManetteMapping"


### PR DESCRIPTION
Reason for change:
 Added additional key check to game controller detect logic
 Added a udev rule to set required gamepad attributes for input device
Test Procedure: libmanette detects both Joycon left/right controllers 
Risks: Low
Priority: P1
Signed-off-by: Ganesh Sahu <ganeshprasad_sahu@comcast.com>

Change-Id: I28b151e226af605065767a97c96698c3622e6523
 (cherry picked from commit 3b9f2fd9e139725f038daa1a3431eacc0f9d674f)