### PR TITLE
RDKOSS-612: Resolving improper PKCS#11 ENGINE cleanup to fix the crash.

### DIFF
--- a/recipes-connectivity/openssl/openssl/pkcs11_engine_cleanup_crash_fix.patch
+++ b/recipes-connectivity/openssl/openssl/pkcs11_engine_cleanup_crash_fix.patch
@@ -1,0 +1,71 @@
+Index: openssl-3.0.5/crypto/evp/p_legacy.c
+===================================================================
+--- openssl-3.0.5.orig/crypto/evp/p_legacy.c
++++ openssl-3.0.5/crypto/evp/p_legacy.c
+@@ -65,7 +65,7 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey,
+         unsigned char key_id = extract_pkcs11_key_id(key);
+         if (key_id == 0x2c) {
+            EC_KEY *loaded_key = NULL;
+-           loaded_key = (EC_KEY *)load_pkcs11_private_key((void *)&key, PKCS11_KEY_TYPE_EC_KEY);
++           loaded_key = (EC_KEY *)load_pkcs11_private_key((void **)&key, PKCS11_KEY_TYPE_EC_KEY);
+             if (!loaded_key)
+                 return 0;
+             key = loaded_key;
+Index: openssl-3.0.5/crypto/pkcs11_reference_key.c
+===================================================================
+--- openssl-3.0.5.orig/crypto/pkcs11_reference_key.c
++++ openssl-3.0.5/crypto/pkcs11_reference_key.c
+@@ -114,31 +114,30 @@ EVP_PKEY *load_pkcs11_private_key_intern
+   engine = ENGINE_by_id("pkcs11");
+   if (!engine) {
+       ERR_raise(ERR_LIB_EVP, ERR_R_ENGINE_LIB);
+-      goto cleanup;
++      return NULL;
+   }
+   /* Configure PKCS#11 module path */
+   if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", PKCS11_MODULE_PATH, 0)) {
+       ERR_raise(ERR_LIB_EVP, ERR_R_ENGINE_LIB);
+-      goto cleanup;
++      return NULL;
+   }
+   /* Initialize engine */
+   if (!ENGINE_init(engine)) {
+       ERR_raise(ERR_LIB_EVP, ERR_R_ENGINE_LIB);
+-      goto cleanup;
++      return NULL;
+   }
+   /* Load private key from PKCS#11 token */
+   loaded_key = ENGINE_load_private_key(engine, pkcs11_uri, NULL, NULL);
+-  if (!loaded_key) {
++  if (loaded_key == NULL) {
+       ERR_raise(ERR_LIB_EVP, ERR_R_ENGINE_LIB);
+-      goto cleanup;
+-  }
+- cleanup:
+-  if (engine) {
+       ENGINE_finish(engine);
+       ENGINE_free(engine);
+   }
+-     OPENSSL_free(pkcs11_uri);
+-     return loaded_key;
++  else {
++      ENGINE_free(engine);
++  }
++  OPENSSL_free(pkcs11_uri);
++  return loaded_key;
+ }
+ 
+ /*
+Index: openssl-3.0.5/crypto/pkcs12/p12_kiss.c
+===================================================================
+--- openssl-3.0.5.orig/crypto/pkcs12/p12_kiss.c
++++ openssl-3.0.5/crypto/pkcs12/p12_kiss.c
+@@ -113,7 +113,7 @@ int PKCS12_parse(PKCS12 *p12, const char
+     }
+     /* Check if parsed key is PKCS#11 reference and load actual key from hardware */
+     if (pkey && *pkey && is_pkcs11_reference_key(*pkey, PKCS11_KEY_TYPE_EVP_PKEY)) {
+-       if (!load_pkcs11_private_key(pkey, PKCS11_KEY_TYPE_EVP_PKEY))  {
++       if (!load_pkcs11_private_key((void **)pkey, PKCS11_KEY_TYPE_EVP_PKEY))  {
+            goto err;
+        }
+     }

--- a/recipes-connectivity/openssl/openssl_3.0.%.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.%.bbappend
@@ -13,6 +13,7 @@ EXTRA_OECONF += "no-tls1_1"
 SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_canarytool', ' file://openssl-canary-3.0.5.patch', '', d)}"
 SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd logendpoints', bb.utils.contains('DISTRO_FEATURES', 'enable_canarytool', ' file://endpoint-logging-canary-enable-3.0.5.patch', 'file://endpoint-logging-canary-disable-3.0.5.patch', d), '', d)}"
 SRC_URI:append = " file://pkcs11_migration_support_p12.patch"
+SRC_URI:append = " file://pkcs11_engine_cleanup_crash_fix.patch"
 
 DEPENDS:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' systemd', '', d)}"
 LDFLAGS =+ "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', ' -lsystemd ', '', d)}"


### PR DESCRIPTION
Resolving improper PKCS#11 ENGINE cleanup to fix the crash.”

Reason for change: Fixing the intermittent crash caused by improper PKCS#11 ENGINE cleanup. Test Procedure: Ensure NO crash on the components rfcmgr,telemetry
               (crash frames should not point to pkcs11 engine APIs).
Risks: low