### PR TITLE
RDKOSS-709: handle revoked evdev devices

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -456,7 +456,7 @@ PACKAGE_ARCH:pn-libinput ?= "${OSS_LAYER_ARCH}"
 PR:pn-libjpeg ?= "r0"
 PACKAGE_ARCH:pn-libjpeg ?= "${OSS_LAYER_ARCH}"
 
-PR:pn-libmanette ?= "r4"
+PR:pn-libmanette ?= "r5"
 PACKAGE_ARCH:pn-libmanette ?= "${OSS_LAYER_ARCH}"
 
 PR:pn-libmd ?= "r0"

--- a/recipes-extended/libmanette/libmanette/0004-handle-revoked-evdev-devices.patch
+++ b/recipes-extended/libmanette/libmanette/0004-handle-revoked-evdev-devices.patch
@@ -1,0 +1,73 @@
+From a50dee7f4c5c0c649c30a8b09247c708eb67aff3 Mon Sep 17 00:00:00 2001
+From: Ben Gray <ben.gray@sky.uk>
+Date: Thu, 26 Feb 2026 19:28:07 +0000
+Subject: [PATCH] handle revoked evdev devices
+Source: COMCAST 
+Signed-off-by: Ganesh Sahu <ganeshprasad_sahu@comcast.com>
+
+---
+ src/manette-device.c | 28 ++++++++++++++++++++++------
+ 1 file changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/src/manette-device.c b/src/manette-device.c
+index 0fa5a00..6719712 100644
+--- a/src/manette-device.c
++++ b/src/manette-device.c
+@@ -556,16 +556,32 @@ poll_events (GIOChannel    *source,
+              ManetteDevice *self)
+ {
+   struct input_event evdev_event;
++  int rc;
+ 
+   g_mutex_lock (&self->poll_id_mutex);
+   g_assert (MANETTE_IS_DEVICE (self));
+ 
+-  while (libevdev_has_event_pending (self->evdev_device))
+-    if (libevdev_next_event (self->evdev_device,
+-                             (guint) LIBEVDEV_READ_FLAG_NORMAL,
+-                             &evdev_event) == 0)
++  if (condition & (G_IO_HUP | G_IO_ERR | G_IO_NVAL)) {
++    g_debug ("Evdev poll condition indicates error/disconnect (condition=0x%x), removing poll source",
++             (guint) condition);
++    g_mutex_unlock (&self->poll_id_mutex);
++    return G_SOURCE_REMOVE;
++  }
++
++  while (libevdev_has_event_pending (self->evdev_device)) {
++    rc = libevdev_next_event (self->evdev_device,
++                              (guint) LIBEVDEV_READ_FLAG_NORMAL,
++                              &evdev_event);
++    if (rc == LIBEVDEV_READ_STATUS_SUCCESS) {
+       on_evdev_event (self, &evdev_event);
+ 
++    } else if (rc < 0) {
++      g_debug ("Error reading from evdev (%d), removing poll source", rc);
++      g_mutex_unlock (&self->poll_id_mutex);
++      return G_SOURCE_REMOVE;
++    }
++  }
++
+   g_mutex_unlock (&self->poll_id_mutex);
+   return G_SOURCE_CONTINUE;
+ }
+@@ -620,7 +636,7 @@ manette_device_new (int      fd,
+ 
+   // Poll the events in the thread context.
+   channel = g_io_channel_unix_new (self->fd);
+-  self->event_src = g_io_create_watch (channel,G_IO_IN);
++  self->event_src = g_io_create_watch (channel, G_IO_IN | G_IO_HUP | G_IO_ERR);
+   g_source_set_callback (self->event_src, (GSourceFunc) poll_events,self, NULL);
+   g_source_attach (self->event_src, g_main_context_get_thread_default ());
+   buttons_number = 0;
+@@ -708,7 +724,7 @@ manette_device_change_fd (ManetteDevice  *self,
+ 
+   // Add a new poll for the new fd
+   channel = g_io_channel_unix_new (self->fd);
+-  self->event_src = g_io_create_watch (channel, G_IO_IN);
++  self->event_src = g_io_create_watch (channel, G_IO_IN | G_IO_HUP | G_IO_ERR);
+   g_source_set_callback (self->event_src, (GSourceFunc) poll_events, self, NULL);
+   g_source_attach (self->event_src, g_main_context_get_thread_default ());
+ }
+-- 
+2.34.1
+

--- a/recipes-extended/libmanette/libmanette_0.2.6.bb
+++ b/recipes-extended/libmanette/libmanette_0.2.6.bb
@@ -15,6 +15,7 @@ SRC_URI = "https://download.gnome.org/sources/libmanette/0.2/libmanette-${PV}.ta
            file://0001-nintendo-digital-trigger-dpad-fix.patch \
            file://0001-nintendo-joycon-L-R-detect.patch \
            file://99-gamepad-set-attr.rules \
+           file://0004-handle-revoked-evdev-devices.patch \
            "
 
 SRC_URI[sha256sum] = "63653259a821ec7d90d681e52e757e2219d462828c9d74b056a5f53267636bac"


### PR DESCRIPTION
Reason for change: libmanette is not handling revoked or errored evdev nodes
Test Procedure: Refer the ticket
Risks:  Low
Priority: P1