### PR TITLE
RDKE-971: Fix libarchive version

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -58,7 +58,6 @@ PREFERRED_VERSION_gettext-native = "0.21"
 PREFERRED_VERSION_libdrm = "2.4.110"
 PREFERRED_VERSION_nativesdk-libdrm = "2.4.110"
 PREFERRED_VERSION_sed = "4.1.2"
-PREFERRED_VERSION_libarchive = "3.6.2"
 
 # Workaround to build allarch packags as oss arch
 MULTILIB_VARIANTS:pn-alsa-topology-conf = " multilib "


### PR DESCRIPTION
Reason for change: The libarchive version was unintentionally upgraded to 3.6.2 in OSS Release 4.11.0. Reverting it to 3.6.1.