### PR TITLE
RDKEVD-6333 : Consume OSS Release 4.12.0 in TVVL-MTK

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -58,6 +58,7 @@ PREFERRED_VERSION_gettext-native = "0.21"
 PREFERRED_VERSION_libdrm = "2.4.110"
 PREFERRED_VERSION_nativesdk-libdrm = "2.4.110"
 PREFERRED_VERSION_sed = "4.1.2"
+PREFERRED_VERSION_pango = "1.50.4"
 
 # Workaround to build allarch packags as oss arch
 MULTILIB_VARIANTS:pn-alsa-topology-conf = " multilib "


### PR DESCRIPTION
troubleshooting issues related to librsvg and cairo from meta-lts-mixins https://ccp.sys.comcast.net/browse/RDKEVD-6333