### PR TITLE
RDKOSS-134: Build systemd V250

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -59,6 +59,8 @@ PREFERRED_VERSION_libdrm = "2.4.110"
 PREFERRED_VERSION_nativesdk-libdrm = "2.4.110"
 PREFERRED_VERSION_sed = "4.1.2"
 
+PREFERRED_VERSION_systemd = "1:250%"
+
 # Workaround to build allarch packags as oss arch
 MULTILIB_VARIANTS:pn-alsa-topology-conf = " multilib "
 MULTILIB_VARIANTS:pn-alsa-ucm-conf = " multilib "
@@ -856,6 +858,9 @@ PACKAGE_ARCH:pn-systemd-serialgetty ?= "${OSS_LAYER_ARCH}"
 
 PR:pn-taglib ?= "r0"
 PACKAGE_ARCH:pn-taglib ?= "${OSS_LAYER_ARCH}"
+
+PR:pn-tar ?= "r0"
+PACKAGE_ARCH:pn-tar ?= "${OSS_LAYER_ARCH}"
 
 PR:pn-tcpdump ?= "r0"
 PACKAGE_ARCH:pn-tcpdump ?= "${OSS_LAYER_ARCH}"

--- a/recipes-core/systemd/systemd_250.%.bbappend
+++ b/recipes-core/systemd/systemd_250.%.bbappend
@@ -14,26 +14,7 @@ do_install:append:broadband() {
 
 FILES:${PN}:append:broadband = " ${sysconfdir}/sysctl.d/50-reservlocalport.conf "
 
-#meta-rdk-comcast/recipes-core/systemd/systemd_%.bbappend
 
-inherit comcast-package-deploy
-
-def get_download_apps(d):
-    download_apps = d.getVar("BPN", True) + '-analyze'
-    mlprefix = d.getVar("MLPREFIX", True).strip()
-    print("mlprefix is [%s]" %mlprefix)
-    if bb.utils.contains("DISTRO_FEATURES", "rdm mixmode", True, False, d):
-        if mlprefix != "" :
-            return download_apps
-    elif bb.utils.contains("DISTRO_FEATURES", "rdm", True, False, d):
-        return download_apps
-    return ""
-
-DOWNLOAD_APPS = "${@get_download_apps(d)}"
-CUSTOM_PKG_EXTNS = "analyze"
-SKIP_MAIN_PKG = "yes"
-DOWNLOAD_ON_DEMAND = "yes"
-DOWNLOAD_METHOD_CONTROLLER = "RFC"
 #meta-rdk-comcast/recipes-core/systemd/systemd_250.5.bbappend
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:${THISDIR}/backports:${THISDIR}/${BPN}:"
 
@@ -45,6 +26,7 @@ SRC_URI += "file://systemd250-tmpfiles.patch \
             file://0001-Added-Extra-information-for-NTP-Status-250.patch  \
             file://systemd250-ntp-event-trigger.patch \
             file://0001-In-our-echo-system-we-are-managing-last-known-good-t-250.patch \
+            ${@bb.utils.contains('DISTRO_FEATURES', 'systimemgr', ' file://systemtimemgr_ntp.patch', '', d)} \
             file://0001_systemd250_reduce_journal_rotation_logging.patch \
             "
 
@@ -54,13 +36,12 @@ PACKAGECONFIG:append = " timesyncd"
 
 do_install:append() {
         install -d ${D}/media/tsb
-	#Enable comcast ntp server in timesyncd.conf
+	#Configure NTP server (time.google.com) in timesyncd.conf
 	if [ -n "${@bb.utils.contains('PACKAGECONFIG', 'timesyncd', 'timesyncd', '', d)}" ]; then
-	   sed -i -e 's/^#NTP=.*/NTP=ntp.ccp.xcal.tv/g' ${D}${sysconfdir}/systemd/timesyncd.conf
+	   sed -i -e 's/^#NTP=.*/NTP=time.google.com/g' ${D}${sysconfdir}/systemd/timesyncd.conf
            #Patch for CISCOXI4-2785: remove ProtectSystem=full from systemd-timesyncd.service
            sed -i -e '/ProtectSystem=/a ReadWritePaths=\/tmp' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
            sed -i -e '/PrivateTmp=yes/d' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
-	   sed -i -e 's/ExecStart=\!\!\/lib\/systemd\/systemd-timesyncd/ExecStartPre=\!\!\/bin\/sh -c \/lib\/rdk\/default-time-setter.sh\n&/' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
            sed -i -e 's/^LockPersonality=yes.*/LockPersonality=false/g' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
            sed -i -e 's/^MemoryDenyWriteExecute=yes.*/MemoryDenyWriteExecute=false/g' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
            sed -i -e 's/^NoNewPrivileges=yes.*/NoNewPrivileges=false/g' ${D}${systemd_unitdir}/system/systemd-timesyncd.service
@@ -136,24 +117,14 @@ PACKAGECONFIG:remove:libc-uclibc = "sysusers machined"
 DEPENDS += " ${@bb.utils.contains("DISTRO_FEATURES", "apparmor", " apparmor", "" ,d)}"
 PACKAGECONFIG:append = " ${@bb.utils.contains("DISTRO_FEATURES", "apparmor", " apparmor", "" ,d)}"
 
+#Remove volatile bind dependency as it is not an oss delivered component
+RDEPENDS:${PN}:remove = "volatile-binds"
+
 EXTRA_OECONF += "--disable-ldconfig"
 EXTRA_OECONF:append:libc-uclibc = " --disable-sysusers --disable-machined "
 
 CFLAGS:append:arm = " -fno-lto"
 
-SRC_URI += " \
-	    file://50-coredump.conf \
-	    file://50-panic.conf \
-	    file://50-netfilter.conf \
-           file://50-portreserv.conf \
-           file://traffic-filter.conf \
-           file://protected_regular.conf \
-           "
-SRC_URI:append = " \
-            file://usb-mount@.service \
-            file://usb-mount.sh \
-            file://99-usb-mount.rules \
-           "
 BACKPORTS ?= " "
 
 RRECOMMENDS:${PN} += " \
@@ -161,36 +132,10 @@ RRECOMMENDS:${PN} += " \
         util-linux-libmount util-linux-umount \
 "
 
-PACKAGES =+ "${PN}-usb-support"
-
-FILES:${PN}-usb-support = " \
-        /usb \
-        /usb0 \
-        /usb1 \
-        ${systemd_unitdir}/system/usb-mount@.service \
-        ${sbindir}/usb-mount.sh \
-        ${sysconfdir}/udev/rules.d/99-usb-mount.rules \
-        ${rootlibexecdir}/udev/rules.d/99-usb-mount.rules \
-       "
-
 FILES:${PN}:append = " ${datadir}/bash-completion"
-FILES:${PN}:append = " ${sbindir}/usb-mount.sh"
 
 do_install:append() {
-	install -d ${D}${sysconfdir}/sysctl.d
 	install -d ${D}${localstatedir}/lib/systemd/coredump
-	install -m 644 ${WORKDIR}/50-coredump.conf ${D}${sysconfdir}/sysctl.d
-	install -m 644 ${WORKDIR}/50-panic.conf ${D}${sysconfdir}/sysctl.d
-	install -m 644 ${WORKDIR}/50-netfilter.conf ${D}${sysconfdir}/sysctl.d
-	install -m 644 ${WORKDIR}/traffic-filter.conf ${D}${sysconfdir}/sysctl.d
-        install -m 644 ${WORKDIR}/protected_regular.conf ${D}${sysconfdir}/sysctl.d
-        mkdir -pv ${D}/usb
-        mkdir -pv ${D}/usb0
-        mkdir -pv ${D}/usb1
-        install -D -m 0644 ${S}/../usb-mount@.service ${D}${systemd_unitdir}/system/usb-mount@.service
-        install -D -m 0755 ${S}/../usb-mount.sh ${D}${sbindir}/usb-mount.sh
-        install -D -m 0644 ${S}/../99-usb-mount.rules ${D}${sysconfdir}/udev/rules.d/99-usb-mount.rules
-        install -D -m 0644 ${S}/../99-usb-mount.rules ${D}${rootlibexecdir}/udev/rules.d/99-usb-mount.rules
         ln -s /dev/null ${D}${sysconfdir}/udev/rules.d/80-net-setup-link.rules
 
         sed -i -e 's/^#DumpCore=.*$/DumpCore=yes/g' ${D}${sysconfdir}/systemd/system.conf
@@ -241,9 +186,6 @@ do_install:append:client() {
         rm -rf ${D}${rootlibexecdir}/systemd/systemd-update-done
         rm -rf ${D}${rootlibexecdir}/systemd/system/systemd-update-done.service
         rm -rf ${D}${rootlibexecdir}/systemd/system/sysinit.target.wants/systemd-update-done.service
-	sed -i '$a\net.ipv4.conf.all.send_redirects=0' ${D}${sysconfdir}/sysctl.d/traffic-filter.conf
-        sed -i '$a\net.ipv4.conf.default.send_redirects=0' ${D}${sysconfdir}/sysctl.d/traffic-filter.conf
-        sed -i '$a\net.ipv4.route.flush = 1' ${D}${sysconfdir}/sysctl.d/traffic-filter.conf
         sed -i -e 's/systemd-update-done.service//g' ${D}${systemd_unitdir}/system/systemd-journal-catalog-update.service
         sed -i -e 's/systemd-update-done.service//g' ${D}${systemd_unitdir}/system/systemd-sysusers.service || true
 }
@@ -329,3 +271,47 @@ do_install:append:hybrid() {
 do_install:append() {
     install -Dm 0644 ${WORKDIR}/99-default.preset ${D}${systemd_unitdir}/system-preset/99-default.preset
 }
+#meta-rdk-comcast-video/recipes-core/systemd/systemd_%.bbappend
+SRC_URI:append:client = " file://0001-no-exec-mount-opt-shm_v250.patch"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'benchmark_enable', 'false', 'true', d)}; then
+    sed -i -e 's/Options=/Options=nosuid,nodev,noexec,/' ${D}${systemd_unitdir}/system/tmp.mount
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'syslog-ng', 'false', 'true', d)}; then
+        #Journal conf overide
+        sed -i -e 's/.*ForwardToSyslog=.*/#ForwardToSyslog=no/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxUse=.*/SystemMaxUse=8M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*RuntimeMaxUse=.*/RuntimeMaxUse=8M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*RuntimeMaxFileSize=.*/RuntimeMaxFileSize=4M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxFileSize=.*/SystemMaxFileSize=4M/g' ${D}${sysconfdir}/systemd/journald.conf
+    else
+        #Update Journal configuration if syslog-ng is enabled
+        sed -i -e 's/.*ForwardToSyslog=.*/#ForwardToSyslog=no/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*RuntimeMaxFileSize=.*/RuntimeMaxFileSize=3M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxUse=.*/SystemMaxUse=3M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxFileSize=.*/SystemMaxFileSize=3M/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*RuntimeMaxFiles=.*/RuntimeMaxFiles=2/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxFiles=.*/SystemMaxFiles=2/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*RuntimeMaxUse=.*/RuntimeMaxUse=3M/g' ${D}${sysconfdir}/systemd/journald.conf
+    fi
+}
+
+do_install:append:client() {
+        install -d ${D}/media/tsb
+}
+
+do_install:append:hybrid() {
+        install -d ${D}/media/tsb
+}
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'syslog-ng', 'false', 'true', d)}; then
+        #Journal conf overide
+        sed -i -e 's/.*RuntimeMaxFiles=.*/RuntimeMaxFiles=2/g' ${D}${sysconfdir}/systemd/journald.conf
+        sed -i -e 's/.*SystemMaxFiles=.*/SystemMaxFiles=2/g' ${D}${sysconfdir}/systemd/journald.conf
+    fi
+}
+
+

--- a/recipes-extended/tar/tar-1.17/avoid_heap_overflow.patch
+++ b/recipes-extended/tar/tar-1.17/avoid_heap_overflow.patch
@@ -1,0 +1,23 @@
+Upstream-Status: Inappropriate [bugfix: http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-0624]
+CVE: CVE-2010-0624
+
+This patch avoids heap overflow reported by :
+http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-0624
+
+This is a clean patch for the GPLv2 tar recipe.
+
+Nitin A Kamble <nitin.a.kamble@intel.com> 2011/04/25
+
+Index: tar-1.17/lib/rtapelib.c
+===================================================================
+--- tar-1.17.orig/lib/rtapelib.c
++++ tar-1.17/lib/rtapelib.c
+@@ -570,7 +570,7 @@ rmt_read__ (int handle, char *buffer, si
+ 
+   sprintf (command_buffer, "R%lu\n", (unsigned long) length);
+   if (do_command (handle, command_buffer) == -1
+-      || (status = get_status (handle)) == SAFE_READ_ERROR)
++      || ((status = get_status (handle)) == SAFE_READ_ERROR) || (status > length))
+     return SAFE_READ_ERROR;
+ 
+   for (counter = 0; counter < status; counter += rlen, buffer += rlen)

--- a/recipes-extended/tar/tar-1.17/gcc43build.patch
+++ b/recipes-extended/tar/tar-1.17/gcc43build.patch
@@ -1,0 +1,37 @@
+Upstream-Status: Inappropriate [licensing]
+
+# Fix errors when built with gcc 4.3
+# Patch taken from Debian bug #452096
+
+diff -urN tar-1.17.orig/lib/argp-fmtstream.h tar-1.17/lib/argp-fmtstream.h
+--- tar-1.17.orig/lib/argp-fmtstream.h	2006-01-11 12:24:05.000000000 -0800
++++ tar-1.17/lib/argp-fmtstream.h	2010-07-22 22:36:12.000000000 -0700
+@@ -198,7 +198,11 @@
+ #endif
+ 
+ #ifndef ARGP_FS_EI
+-#define ARGP_FS_EI extern inline
++ #if defined __GNUC_STDC_INLINE__
++   #define ARGP_FS_EI extern inline __attribute__((__gnu_inline__))
++ #else
++   #define ARGP_FS_EI extern inline
++ #endif
+ #endif
+ 
+ ARGP_FS_EI size_t
+diff -urN tar-1.17.orig/lib/argp.h tar-1.17/lib/argp.h
+--- tar-1.17.orig/lib/argp.h	2007-03-30 00:09:11.000000000 -0700
++++ tar-1.17/lib/argp.h	2010-07-22 22:38:44.000000000 -0700
+@@ -580,7 +580,11 @@
+ # endif
+ 
+ # ifndef ARGP_EI
+-#  define ARGP_EI extern __inline__
++#  if defined __GNUC_STDC_INLINE__
++#    define ARGP_EI extern __inline__ __attribute__((__gnu_inline__))
++#  else
++#    define ARGP_EI extern __inline__
++#  endif
+ # endif
+ 
+ ARGP_EI void

--- a/recipes-extended/tar/tar-1.17/m4extensions.patch
+++ b/recipes-extended/tar/tar-1.17/m4extensions.patch
@@ -1,0 +1,30 @@
+Upstream-Status: Inappropriate [licensing]
+
+# Define AC_USE_SYSTEM_EXTENSIONS only if it was previously undefined.
+# This is needed to configure correctly with newer versions of autoconf.
+
+--- tar-1.17/m4/extensions.m4.orig	2010-07-22 22:21:35.000000000 -0700
++++ tar-1.17/m4/extensions.m4	2010-07-22 22:23:41.000000000 -0700
+@@ -1,4 +1,4 @@
+-# serial 4  -*- Autoconf -*-
++# serial 5  -*- Autoconf -*-
+ # Enable extensions on systems that normally disable them.
+ 
+ # Copyright (C) 2003, 2006 Free Software Foundation, Inc.
+@@ -16,6 +16,7 @@
+ # ------------------------
+ # Enable extensions on systems that normally disable them,
+ # typically due to standards-conformance issues.
++m4_ifdef([AC_USE_SYSTEM_EXTENSIONS], [], [
+ AC_DEFUN([AC_USE_SYSTEM_EXTENSIONS],
+ [
+   AC_BEFORE([$0], [AC_COMPILE_IFELSE])
+@@ -48,7 +49,7 @@
+     AC_DEFINE([__EXTENSIONS__])
+   AC_DEFINE([_POSIX_PTHREAD_SEMANTICS])
+   AC_DEFINE([_TANDEM_SOURCE])
+-])
++])])
+ 
+ # gl_USE_SYSTEM_EXTENSIONS
+ # ------------------------

--- a/recipes-extended/tar/tar.inc
+++ b/recipes-extended/tar/tar.inc
@@ -1,0 +1,52 @@
+SUMMARY = "GNU file archiving program"
+DESCRIPTION = "GNU tar saves many files together into a single tape \
+or disk archive, and can restore individual files from the archive."
+HOMEPAGE = "http://www.gnu.org/software/tar/"
+SECTION = "base"
+
+SRC_URI = "${GNU_MIRROR}/tar/tar-${PV}.tar.bz2"
+
+inherit autotools gettext texinfo
+
+EXTRA_OECONF += "DEFAULT_RMT_DIR=${base_sbindir}"
+
+# Let aclocal use the relative path for the m4 file rather than the
+# absolute since tar has a lot of m4 files, otherwise there might
+# be an "Argument list too long" error when it is built in a long/deep
+# directory.
+acpaths = "-I ./m4"
+
+do_install () {
+    autotools_do_install
+    ln -s tar ${D}${bindir}/gtar
+}
+
+do_install:append:class-target() {
+    if [ "${base_bindir}" != "${bindir}" ]; then
+        install -d ${D}${base_bindir}
+        mv ${D}${bindir}/tar ${D}${base_bindir}/tar
+        mv ${D}${bindir}/gtar ${D}${base_bindir}/gtar
+        rmdir ${D}${bindir}/
+    fi
+}
+
+PACKAGES =+ "${PN}-rmt"
+
+FILES:${PN}-rmt = "${base_sbindir}/rmt*"
+
+inherit update-alternatives
+
+ALTERNATIVE_PRIORITY = "100"
+
+ALTERNATIVE:${PN} = "tar"
+ALTERNATIVE:${PN}-rmt = "rmt"
+ALTERNATIVE:${PN}:class-nativesdk = ""
+ALTERNATIVE:${PN}-rmt:class-nativesdk = ""
+
+ALTERNATIVE_LINK_NAME[tar] = "${base_bindir}/tar"
+ALTERNATIVE_LINK_NAME[rmt] = "${base_sbindir}/rmt"
+
+PROVIDES:append:class-native = " tar-replacement-native"
+NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-extended/tar/tar/0001-lib-argp-parse.c-Fix-compiler-error.patch
+++ b/recipes-extended/tar/tar/0001-lib-argp-parse.c-Fix-compiler-error.patch
@@ -1,0 +1,35 @@
+From 153c0aab9e2a4a97b1a2c6b530594cd9a211e9ec Mon Sep 17 00:00:00 2001
+From: Joakim Roubert <joakimr@axis.com>
+Date: Thu, 6 Dec 2018 10:33:14 +0100
+Subject: [PATCH] lib/argp-parse.c: Fix compiler error
+
+This avoids the following error:
+
+  lib/argp-parse.c: In function 'argp_version_parser':
+  lib/argp-parse.c:158:2: error: format not a string literal and no
+  format arguments [-Werror=format-security]
+    __argp_error (state, dgettext (state->root_argp->argp_domain,
+    ^~~~~~~~~~~~
+
+Upstream-Status: Inappropriate [old version]
+Signed-off-by: Joakim Roubert <joakim.roubert@axis.com>
+---
+ lib/argp-parse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/argp-parse.c b/lib/argp-parse.c
+index a7de729..09511ba 100644
+--- a/lib/argp-parse.c
++++ b/lib/argp-parse.c
+@@ -155,7 +155,7 @@ argp_version_parser (int key, char *arg, struct argp_state *state)
+       else if (argp_program_version)
+ 	fprintf (state->out_stream, "%s\n", argp_program_version);
+       else
+-	__argp_error (state, dgettext (state->root_argp->argp_domain,
++	__argp_error (state, "%s", dgettext (state->root_argp->argp_domain,
+ 				       "(PROGRAM ERROR) No version known!?"));
+       if (! (state->flags & ARGP_NO_EXIT))
+ 	exit (0);
+-- 
+2.11.0
+

--- a/recipes-extended/tar/tar_1.17.bb
+++ b/recipes-extended/tar/tar_1.17.bb
@@ -1,0 +1,15 @@
+require tar.inc
+
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
+
+PR = "r3"
+
+SRC_URI += "file://m4extensions.patch \
+    file://gcc43build.patch \
+    file://avoid_heap_overflow.patch \
+    file://0001-lib-argp-parse.c-Fix-compiler-error.patch \
+    "
+
+SRC_URI[md5sum] = "c6c4f1c075dbf0f75c29737faa58f290"
+SRC_URI[sha256sum] = "19f9021dda51a16295e4706e80870e71f87107675e51c176a491eba0fc4ca492"


### PR DESCRIPTION
Reason for the change:
Configured systemd PREFERRED version to 1:250
Backport tar_1.17 recipe which is gplv2 licenced required for building systemd v250 Backport missing systemd v250 changes for RDKE
Remove reference to default-time-setter.sh script in systemd-timesyncd to fix the build error