### PR TITLE
RDKEMW-18031: sky Cinema video freezes after seek and resume

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.18/files/0038-fix-for-switching-from-clear-to-encrypted-and-vice-v.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.18/files/0038-fix-for-switching-from-clear-to-encrypted-and-vice-v.patch
@@ -87,7 +87,7 @@ index a8de084ff..adebcbda5 100644
 +    if (qtdemux->aamp_player_enabled  && stream->protected == FALSE)
 +      stream->protected = TRUE;
 +
-+    if (qtdemux->aamp_player_enabled)
++    if (qtdemux->aamp_player_enabled && (stream->protection_scheme_type == 0))
 +      stream->protection_scheme_type = FOURCC_cenc;
 +
      if (stream->protected) {


### PR DESCRIPTION
Reason for change: sky Cinema video freezes after seeking and resuming playback Test Procedure: None
Risks: Low
Priority: P0
Signed-off-by:mkooda197@cable.comcast.com