### PR TITLE
RDKOSS-930: Add preferred gupnp version

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -36,6 +36,7 @@ PREFERRED_VERSION_civetweb = "1.10+git%"
 PREFERRED_VERSION_wpa-supplicant = "2.10"
 PREFERRED_VERSION_dnsmasq = "2.90"
 PREFERRED_VERSION_msgpack-c = "4.0.0%"
+PREFERRED_VERSION_gupnp ?= "0.20.10"
 
 #Fix the version diff against stable2
 PREFERRED_VERSION_libstd-rs = "1.82.0"


### PR DESCRIPTION
Reason for change: Default value is set to 0.20.10 which can be overriden in middleware
Test procedure: No build failure should be ther
Risk: Low