### PR TITLE
RDKE-1040: OSS release version 4.13.0

### DIFF
--- a/conf/include/package_revisions_oss.inc
+++ b/conf/include/package_revisions_oss.inc
@@ -19,7 +19,7 @@ def get_oss_arch(d):
     arch += "-oss"
     return arch
 
-OSS_LAYER_VERSION = "4.12.5"
+OSS_LAYER_VERSION = "4.13.0"
 
 LAYER_EXTENSION ?= ""
 OSS_LAYER_ARCH = "${@get_oss_arch(d)}${LAYER_EXTENSION}"

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -7,7 +7,7 @@ PACKAGE_ARCH = "${OSS_LAYER_ARCH}"
 inherit packagegroup
 
 
-PV = "4.12.5"
+PV = "4.13.0"
 PR = "r0"
 
 # poky components


### PR DESCRIPTION
Reason for change: Set OSS release version 4.13.0 in corresponding files