### PR TITLE
RDKEMW-18472: CVE-2025-15467 fix for openssl

### DIFF
--- a/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
@@ -1,0 +1,32 @@
+From 591243ce65e8bc71080d8737783b74575aea868d Mon Sep 17 00:00:00 2001
+From: GitHub Actions <github-actions[bot]@users.noreply.github.com>
+Date: Wed, 27 May 2026 07:57:53 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-15467
+
+Fix CVE-2025-15467 in openssl 3.0.15.
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/2c8f0e5fa9b6ee5508a0349e4572ddb74db5a703.patch]
+CVE: CVE-2025-15467
+CVE: [CVE-2025-15467]
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/evp/evp_lib.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/evp/evp_lib.c b/crypto/evp/evp_lib.c
+index 4f3d901..55cc9ca 100644
+--- a/crypto/evp/evp_lib.c
++++ b/crypto/evp/evp_lib.c
+@@ -249,10 +249,9 @@ int evp_cipher_get_asn1_aead_params(EVP_CIPHER_CTX *c, ASN1_TYPE *type,
+     if (type == NULL || asn1_params == NULL)
+         return 0;
+ 
+-    i = ossl_asn1_type_get_octetstring_int(type, &tl, NULL, EVP_MAX_IV_LENGTH);
+-    if (i <= 0)
++    i = ossl_asn1_type_get_octetstring_int(type, &tl, iv, EVP_MAX_IV_LENGTH);
++    if (i <= 0 || i > EVP_MAX_IV_LENGTH)
+         return -1;
+-    ossl_asn1_type_get_octetstring_int(type, &tl, iv, i);
+ 
+     memcpy(asn1_params->iv, iv, i);
+     asn1_params->iv_len = i;

--- a/recipes-connectivity/openssl/openssl_3.0.15.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.15.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://CVE-2025-15467_openssl_3.0.15_fix.patch"
+


### PR DESCRIPTION
CVE: CVE-2025-15467
Component: openssl
Patch: CVE-2025-15467_openssl_3.0.15_fix.patch
Bbappend: openssl_3.0.15.bbappend

Auto-committed by CVE pipeline run 26495267715