### PR TITLE
RDKEMW-18472: CVE-2025-15467 fix for openssl

### DIFF
--- a/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
@@ -1,0 +1,32 @@
+From 2d3a2d1d6f76331eb6650ad38135827b5923361d Mon Sep 17 00:00:00 2001
+From: GitHub Actions <github-actions[bot]@users.noreply.github.com>
+Date: Fri, 29 May 2026 06:19:42 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-15467
+
+Fix CVE-2025-15467 in openssl 3.0.15.
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/2c8f0e5fa9b6ee5508a0349e4572ddb74db5a703.patch]
+CVE: CVE-2025-15467
+CVE: [CVE-2025-15467]
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/evp/evp_lib.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/evp/evp_lib.c b/crypto/evp/evp_lib.c
+index 4f3d901..55cc9ca 100644
+--- a/crypto/evp/evp_lib.c
++++ b/crypto/evp/evp_lib.c
+@@ -249,10 +249,9 @@ int evp_cipher_get_asn1_aead_params(EVP_CIPHER_CTX *c, ASN1_TYPE *type,
+     if (type == NULL || asn1_params == NULL)
+         return 0;
+ 
+-    i = ossl_asn1_type_get_octetstring_int(type, &tl, NULL, EVP_MAX_IV_LENGTH);
+-    if (i <= 0)
++    i = ossl_asn1_type_get_octetstring_int(type, &tl, iv, EVP_MAX_IV_LENGTH);
++    if (i <= 0 || i > EVP_MAX_IV_LENGTH)
+         return -1;
+-    ossl_asn1_type_get_octetstring_int(type, &tl, iv, i);
+ 
+     memcpy(asn1_params->iv, iv, i);
+     asn1_params->iv_len = i;

--- a/recipes-connectivity/openssl/openssl_3.0.15.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.15.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://CVE-2025-15467_openssl_3.0.15_fix.patch"
+


### PR DESCRIPTION
Auto-created by CVE pipeline.\n\n- CVE: CVE-2025-15467\n- Component: openssl\n- JIRA: RDKEMW-18472\n- Workflow run: https://github.com/rdk-common/sslcerts-cpc/actions/runs/26516033052