### PR TITLE
CVE: automated patch for RDKEMW-19478

### DIFF
--- a/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-15467_openssl_3.0.15_fix.patch
@@ -1,0 +1,31 @@
+From bb8d454319557a2e9e7b61bd30d829cdf37fa95a Mon Sep 17 00:00:00 2001
+From: GitHub Actions <github-actions[bot]@users.noreply.github.com>
+Date: Sun, 7 Jun 2026 12:17:24 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-15467
+
+Fix CVE-2025-15467 in openssl 3.0.15.
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/2c8f0e5fa9b6ee5508a0349e4572ddb74db5a703.patch]
+CVE: CVE-2025-15467
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/evp/evp_lib.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/evp/evp_lib.c b/crypto/evp/evp_lib.c
+index 4f3d901..55cc9ca 100644
+--- a/crypto/evp/evp_lib.c
++++ b/crypto/evp/evp_lib.c
+@@ -249,10 +249,9 @@ int evp_cipher_get_asn1_aead_params(EVP_CIPHER_CTX *c, ASN1_TYPE *type,
+     if (type == NULL || asn1_params == NULL)
+         return 0;
+ 
+-    i = ossl_asn1_type_get_octetstring_int(type, &tl, NULL, EVP_MAX_IV_LENGTH);
+-    if (i <= 0)
++    i = ossl_asn1_type_get_octetstring_int(type, &tl, iv, EVP_MAX_IV_LENGTH);
++    if (i <= 0 || i > EVP_MAX_IV_LENGTH)
+         return -1;
+-    ossl_asn1_type_get_octetstring_int(type, &tl, iv, i);
+ 
+     memcpy(asn1_params->iv, iv, i);
+     asn1_params->iv_len = i;

--- a/recipes-connectivity/openssl/openssl/CVE-2025-69419_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-69419_openssl_3.0.15_fix.patch
@@ -1,0 +1,48 @@
+From 6b5ac3c92ac0a63841160dcb9393c45b9a910df1 Mon Sep 17 00:00:00 2001
+From: GitHub Actions <github-actions[bot]@users.noreply.github.com>
+Date: Sun, 7 Jun 2026 13:09:15 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-69419
+
+Fix CVE-2025-69419 in openssl 3.0.15.
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/41be0f216404f14457bbf3b9cc488dba60b49296.patch]
+CVE: CVE-2025-69419
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/asn1/a_strex.c   | 6 ++++--
+ crypto/pkcs12/p12_utl.c | 5 +++++
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/asn1/a_strex.c b/crypto/asn1/a_strex.c
+index a6049f7..a490dfe 100644
+--- a/crypto/asn1/a_strex.c
++++ b/crypto/asn1/a_strex.c
+@@ -204,8 +204,10 @@ static int do_buf(unsigned char *buf, int buflen,
+             orflags = CHARTYPE_LAST_ESC_2253;
+         if (type & BUF_TYPE_CONVUTF8) {
+             unsigned char utfbuf[6];
+-            int utflen;
+-            utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++            int utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++
++            if (utflen < 0)
++                return -1; /* error happened with UTF8 */
+             for (i = 0; i < utflen; i++) {
+                 /*
+                  * We don't need to worry about setting orflags correctly
+diff --git a/crypto/pkcs12/p12_utl.c b/crypto/pkcs12/p12_utl.c
+index 3afc8b2..4e00bef 100644
+--- a/crypto/pkcs12/p12_utl.c
++++ b/crypto/pkcs12/p12_utl.c
+@@ -213,6 +213,11 @@ char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)
+     for (asclen = 0, i = 0; i < unilen; ) {
+         j = bmp_to_utf8(asctmp+asclen, uni+i, unilen-i);
+         if (j == 4) i += 4;
++        /* when UTF8_putc fails */
++        if (j < 0) {
++            OPENSSL_free(asctmp);
++            return NULL;
++        }
+         else        i += 2;
+         asclen += j;
+     }

--- a/recipes-connectivity/openssl/openssl_3.0.15%.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.15%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://CVE-2025-15467_openssl_3.0.15_fix.patch \
+                   file://CVE-2025-69419_openssl_3.0.15_fix.patch \
+"


### PR DESCRIPTION
Automated CVE remediation pipeline output.

JIRA: RDKEMW-19478
CVEs fixed: CVE-2025-15467 CVE-2025-69419
Base tag: 4.12.0
Base branch: develop

Source workflow run:
https://github.com/rdk-common/sslcerts-cpc/actions/runs/27090623677