### PR TITLE
RDKOSS-1001: Enable breakpad mixedmode patch for multilib platforms

### DIFF
--- a/recipes-devtools/breakpad/breakpad_git.bbappend
+++ b/recipes-devtools/breakpad/breakpad_git.bbappend
@@ -1,7 +1,11 @@
 FILESEXTRAPATHS:append := "${THISDIR}/files:"
 
 SRC_URI:append = " file://breakpad_disable_format_macros_check.patch "
-SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'mixmode', 'file://breakpad_mixedmode_fpregs_git.patch', '', d)} "
+
+#SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'mixmode', 'file://breakpad_mixedmode_fpregs_git.patch', '', d)} "
+#Apply this flag for multlib platforms as mixmode feature is not properly maintained in the RDK-E
+SRC_URI:append:lib32 = " file://breakpad_mixedmode_fpregs_git.patch "
+
 
 # From meta-rdk-comcast/recipes-devtools/breakpad/breakpad_git.bbappend
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-devtools/breakpad/breakpad_git.bbappend
+++ b/recipes-devtools/breakpad/breakpad_git.bbappend
@@ -2,9 +2,8 @@ FILESEXTRAPATHS:append := "${THISDIR}/files:"
 
 SRC_URI:append = " file://breakpad_disable_format_macros_check.patch "
 
-#SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'mixmode', 'file://breakpad_mixedmode_fpregs_git.patch', '', d)} "
-#Apply this flag for multlib platforms as mixmode feature is not properly maintained in the RDK-E
-SRC_URI:append:lib32 = " file://breakpad_mixedmode_fpregs_git.patch "
+# Apply this patch on lib32 multilib builds (mixed-mode 32-bit on 64-bit kernels). DISTRO_FEATURES[mixmode] isn't consistently set in RDK-E.
+SRC_URI:append:virtclass-multilib-lib32 = " file://breakpad_mixedmode_fpregs_git.patch "
 
 
 # From meta-rdk-comcast/recipes-devtools/breakpad/breakpad_git.bbappend

--- a/recipes-devtools/breakpad/breakpad_git.bbappend
+++ b/recipes-devtools/breakpad/breakpad_git.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:append := "${THISDIR}/files:"
 
 SRC_URI:append = " file://breakpad_disable_format_macros_check.patch "
 
-# Apply this patch on lib32 multilib builds (mixed-mode 32-bit on 64-bit kernels). DISTRO_FEATURES[mixmode] isn't consistently set in RDK-E.
+# Apply this patch on lib32 multilib builds (mixed-mode 32-bit on 64-bit kernels). DISTRO_FEATURES 'mixmode' isn't consistently set in RDK-E.
 SRC_URI:append:virtclass-multilib-lib32 = " file://breakpad_mixedmode_fpregs_git.patch "
 
 


### PR DESCRIPTION
Reason for change: mixmode in DISTRO_FEATURES is not consistently maintained in RDK-E breakpad_mixedmode_fpregs_git.patch using multilib criteria so it is applied for mixedmode builds reliably.
Test Procedure: Verify breakpad generation and minidump_stackwalk symbol/stack resolution on multilib mixedmode builds; confirm no regression.