### PR TITLE
[RDKEMW-19445] CVE Remediation Bundle

### DIFF
--- a/recipes-connectivity/openssl/openssl/CVE-2025-69420_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-69420_openssl_3.0.15_fix.patch
@@ -1,0 +1,37 @@
+From 36fd6cf3a0c810a0b13d2eae478ccc78644d7673 Mon Sep 17 00:00:00 2001
+From: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+Date: Tue, 23 Jun 2026 12:32:28 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-69420
+
+Upstream-Status: Backport
+CVE: CVE-2025-69420
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/ts/ts_rsp_verify.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/ts/ts_rsp_verify.c b/crypto/ts/ts_rsp_verify.c
+index 792a27c..d940c49 100644
+--- a/crypto/ts/ts_rsp_verify.c
++++ b/crypto/ts/ts_rsp_verify.c
+@@ -209,7 +209,7 @@ static ESS_SIGNING_CERT *ossl_ess_get_signing_cert(const PKCS7_SIGNER_INFO *si)
+     const unsigned char *p;
+ 
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificate);
+-    if (attr == NULL)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT(NULL, &p, attr->value.sequence->length);
+@@ -222,7 +222,7 @@ ESS_SIGNING_CERT_V2 *ossl_ess_get_signing_cert_v2(const PKCS7_SIGNER_INFO *si)
+     const unsigned char *p;
+ 
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificateV2);
+-    if (attr == NULL)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT_V2(NULL, &p, attr->value.sequence->length);
+-- 
+2.25.1
+

--- a/recipes-connectivity/openssl/openssl_3.0.%.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.%.bbappend
@@ -246,3 +246,6 @@ RDEPENDS:${PN}-ptest += " \
     perl-module-cwd \
     perl-module-exporter \
 "
+
+SRC_URI:append = " file://CVE-2025-69420_openssl_3.0.15_fix.patch \
+"


### PR DESCRIPTION
## CVE Remediation Bundle — RDKEMW-19445

Automated bundle generated by the CVE pipeline. This PR adds per-CVE patches and updates the version-specific bbappend(s) to apply them via `SRC_URI:append`.

### Summary

| Bucket | Count |
| --- | ---: |
| ✅ Finalized (built + staged) | 1 |
| ⚠️ Built but finalize failed | 0 |
| ❌ Not built / failed | 0 |
| ⊘ Skipped | 0 |
| **Total** | **1** |

**Commit (push-clone, this branch):** `e8ca73d301ae16f77592071d622bddf52d9d0162`

### ✅ Included CVEs (1)

| CVE | Component | Version | Bbappend | Action | Patch |
| --- | --- | --- | --- | --- | --- |
| `CVE-2025-69420` | `openssl` | `?` | `openssl_3.0.%.bbappend` | reused | `CVE-2025-69420_openssl_3.0.15_fix.patch` |

---

_Generated by [workflow run](https://github.com/rdk-common/sslcerts-cpc/actions/runs/28016257424)._

JIRA: **RDKEMW-19445**
