### PR TITLE
[RDKEMW-20634] CVE Remediation Bundle

### DIFF
--- a/recipes-connectivity/openssl/openssl/CVE-2025-69419_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-69419_openssl_3.0.15_fix.patch
@@ -1,0 +1,49 @@
+From 4b5c6999e9062c43ed9e29d65304de87f7fc945c Mon Sep 17 00:00:00 2001
+From: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+Date: Sat, 27 Jun 2026 16:54:28 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-69419
+
+Upstream-Status: Backport
+CVE: CVE-2025-69419
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/asn1/a_strex.c   | 6 ++++--
+ crypto/pkcs12/p12_utl.c | 5 +++++
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/asn1/a_strex.c b/crypto/asn1/a_strex.c
+index a6049f7..a490dfe 100644
+--- a/crypto/asn1/a_strex.c
++++ b/crypto/asn1/a_strex.c
+@@ -204,8 +204,10 @@ static int do_buf(unsigned char *buf, int buflen,
+             orflags = CHARTYPE_LAST_ESC_2253;
+         if (type & BUF_TYPE_CONVUTF8) {
+             unsigned char utfbuf[6];
+-            int utflen;
+-            utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++            int utflen = UTF8_putc(utfbuf, sizeof(utfbuf), c);
++
++            if (utflen < 0)
++                return -1; /* error happened with UTF8 */
+             for (i = 0; i < utflen; i++) {
+                 /*
+                  * We don't need to worry about setting orflags correctly
+diff --git a/crypto/pkcs12/p12_utl.c b/crypto/pkcs12/p12_utl.c
+index 3afc8b2..4e00bef 100644
+--- a/crypto/pkcs12/p12_utl.c
++++ b/crypto/pkcs12/p12_utl.c
+@@ -213,6 +213,11 @@ char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)
+     for (asclen = 0, i = 0; i < unilen; ) {
+         j = bmp_to_utf8(asctmp+asclen, uni+i, unilen-i);
+         if (j == 4) i += 4;
++        /* when UTF8_putc fails */
++        if (j < 0) {
++            OPENSSL_free(asctmp);
++            return NULL;
++        }
+         else        i += 2;
+         asclen += j;
+     }
+-- 
+2.25.1
+

--- a/recipes-connectivity/openssl/openssl/CVE-2025-69420_openssl_3.0.15_fix.patch
+++ b/recipes-connectivity/openssl/openssl/CVE-2025-69420_openssl_3.0.15_fix.patch
@@ -1,0 +1,37 @@
+From 258bbdcbf675307b179671aa7d2d1c2c1507e964 Mon Sep 17 00:00:00 2001
+From: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+Date: Sat, 27 Jun 2026 16:59:48 +0100
+Subject: [PATCH] openssl: Fix CVE-2025-69420
+
+Upstream-Status: Backport
+CVE: CVE-2025-69420
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ crypto/ts/ts_rsp_verify.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/ts/ts_rsp_verify.c b/crypto/ts/ts_rsp_verify.c
+index 792a27c..d940c49 100644
+--- a/crypto/ts/ts_rsp_verify.c
++++ b/crypto/ts/ts_rsp_verify.c
+@@ -209,7 +209,7 @@ static ESS_SIGNING_CERT *ossl_ess_get_signing_cert(const PKCS7_SIGNER_INFO *si)
+     const unsigned char *p;
+ 
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificate);
+-    if (attr == NULL)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT(NULL, &p, attr->value.sequence->length);
+@@ -222,7 +222,7 @@ ESS_SIGNING_CERT_V2 *ossl_ess_get_signing_cert_v2(const PKCS7_SIGNER_INFO *si)
+     const unsigned char *p;
+ 
+     attr = PKCS7_get_signed_attribute(si, NID_id_smime_aa_signingCertificateV2);
+-    if (attr == NULL)
++    if (attr == NULL || attr->type != V_ASN1_SEQUENCE)
+         return NULL;
+     p = attr->value.sequence->data;
+     return d2i_ESS_SIGNING_CERT_V2(NULL, &p, attr->value.sequence->length);
+-- 
+2.25.1
+

--- a/recipes-connectivity/openssl/openssl_3.0.%.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.0.%.bbappend
@@ -246,3 +246,7 @@ RDEPENDS:${PN}-ptest += " \
     perl-module-cwd \
     perl-module-exporter \
 "
+
+SRC_URI:append = " file://CVE-2025-69419_openssl_3.0.15_fix.patch \
+                   file://CVE-2025-69420_openssl_3.0.15_fix.patch \
+"


### PR DESCRIPTION
## CVE Remediation Bundle — RDKEMW-20634

Automated bundle generated by the CVE pipeline. This PR adds per-CVE patches and updates the version-specific bbappend(s) to apply them via `SRC_URI:append`.

### Summary

| Bucket | Count |
| --- | ---: |
| ✅ Finalized (built + staged) | 2 |
| ⚠️ Built but finalize failed | 0 |
| ❌ Not built / failed | 0 |
| ⊘ Skipped | 0 |
| **Total** | **2** |

**Commit (push-clone, this branch):** `110130faed6141146101fe6347c4a1df8e3de005`

### ✅ Included CVEs (2)

| CVE | Component | Version | Bbappend | Action | Patch |
| --- | --- | --- | --- | --- | --- |
| `CVE-2025-69419` | `openssl` | `?` | `openssl_3.0.%.bbappend` | reused | `CVE-2025-69419_openssl_3.0.15_fix.patch` |
| `CVE-2025-69420` | `openssl` | `?` | `openssl_3.0.%.bbappend` | reused | `CVE-2025-69420_openssl_3.0.15_fix.patch` |

---

_Generated by [workflow run](https://github.com/rdk-common/sslcerts-cpc/actions/runs/28294000446)._

JIRA: **RDKEMW-20634**
