### PR TITLE
RDKOSS-1001:[HF]Enable breakpad mixedmode patch for multilib platforms (#456)

### DIFF
--- a/recipes-devtools/breakpad/breakpad_git.bbappend
+++ b/recipes-devtools/breakpad/breakpad_git.bbappend
@@ -1,7 +1,10 @@
 FILESEXTRAPATHS:append := "${THISDIR}/files:"
 
 SRC_URI:append = " file://breakpad_disable_format_macros_check.patch "
-SRC_URI:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'mixmode', 'file://breakpad_mixedmode_fpregs_git.patch', '', d)} "
+
+# Apply this patch on lib32 multilib builds (mixed-mode 32-bit on 64-bit kernels). DISTRO_FEATURES 'mixmode' isn't consistently set in RDK-E.
+SRC_URI:append:virtclass-multilib-lib32 = " file://breakpad_mixedmode_fpregs_git.patch "
+
 
 # From meta-rdk-comcast/recipes-devtools/breakpad/breakpad_git.bbappend
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION

* RDKOSS-1001: [HOTFIX]  Enable breakpad mixedmode patch for multilib platforms

Reason for change: mixmode in DISTRO_FEATURES is not consistently maintained in RDK-E breakpad_mixedmode_fpregs_git.patch using multilib criteria so it is applied for mixedmode builds reliably.
Test Procedure: Verify breakpad generation and minidump_stackwalk symbol/stack resolution on multilib mixedmode builds; confirm no regression.

* Minor code changes Update breakpad_git.bbappend

* Apply suggestions from code review



---------