### PR TITLE
[RDKEMW-20634] CVE Remediation Bundle

### DIFF
--- a/recipes-support/curl/curl_7.82%.bbappend
+++ b/recipes-support/curl/curl_7.82%.bbappend
@@ -79,3 +79,6 @@ do_install_ptest() {
 FILES:${PN}-ptest += "${PTEST_PATH}/tests/*"
 
 RDEPENDS:${PN}-ptest += "bash"
+
+SRC_URI:append = " file://CVE-2025-15079_curl_7.82.0_fix.patch \
+"

--- a/recipes-support/curl/curl_7.82%/CVE-2025-15079_curl_7.82.0_fix.patch
+++ b/recipes-support/curl/curl_7.82%/CVE-2025-15079_curl_7.82.0_fix.patch
@@ -1,0 +1,31 @@
+From a915b66f8fb72dd82306f7ef17f8918fb8202eec Mon Sep 17 00:00:00 2001
+From: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+Date: Wed, 1 Jul 2026 11:56:52 +0100
+Subject: [PATCH] curl: Fix CVE-2025-15079
+
+Upstream-Status: Backport
+CVE: CVE-2025-15079
+Signed-off-by: RDK CVE Pipeline <rdk-cve-pipeline@comcast.com>
+---
+ lib/vssh/libssh.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/vssh/libssh.c b/lib/vssh/libssh.c
+index 6dad2a2..fa20d62 100644
+--- a/lib/vssh/libssh.c
++++ b/lib/vssh/libssh.c
+@@ -2224,6 +2224,11 @@ static CURLcode myssh_connect(struct Curl_easy *data, bool *done)
+     infof(data, "Known hosts: %s", data->set.str[STRING_SSH_KNOWNHOSTS]);
+     rc = ssh_options_set(ssh->ssh_session, SSH_OPTIONS_KNOWNHOSTS,
+                          data->set.str[STRING_SSH_KNOWNHOSTS]);
++    if(rc == SSH_OK)
++      /* libssh has two separate options for this. Set both to the same file
++         to avoid surprises */
++      rc = ssh_options_set(sshc->ssh_session, SSH_OPTIONS_GLOBAL_KNOWNHOSTS,
++                           data->set.str[STRING_SSH_KNOWNHOSTS]);
+     if(rc != SSH_OK) {
+       failf(data, "Could not set known hosts file path");
+       return CURLE_FAILED_INIT;
+-- 
+2.25.1
+


### PR DESCRIPTION
## CVE Remediation Bundle — RDKEMW-20634

Automated bundle generated by the CVE pipeline. This PR adds per-CVE patches and updates the version-specific bbappend(s) to apply them via `SRC_URI:append`.

### Summary

| Bucket | Count |
| --- | ---: |
| ✅ Finalized (built + staged) | 1 |
| ⚠️ Built but finalize failed | 0 |
| ❌ Not built / failed | 0 |
| ⊘ Skipped | 0 |
| **Total** | **1** |

**Commit (push-clone, this branch):** `e2a4e90e4427fe2eca827c6640c1d0448a088d13`

### ✅ Included CVEs (1)

| CVE | Component | Version | Bbappend | Action | Patch |
| --- | --- | --- | --- | --- | --- |
| `CVE-2025-15079` | `curl` | `?` | `curl_7.82%.bbappend` | reused | `CVE-2025-15079_curl_7.82.0_fix.patch` |

---

_Generated by [workflow run](https://github.com/rdk-common/sslcerts-cpc/actions/runs/28510084471)._

JIRA: **RDKEMW-20634**
