### PR TITLE
RDKOSS-1057 : vulkan-headers compilation error with 1.3.260

### DIFF
--- a/recipes-graphics/vulkan/vulkan-headers.inc
+++ b/recipes-graphics/vulkan/vulkan-headers.inc
@@ -7,9 +7,6 @@ HOMEPAGE = "https://www.khronos.org/vulkan/"
 BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Headers"
 SECTION = "libs"
 
-LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
-
 SRC_URI = "git://github.com/KhronosGroup/Vulkan-Headers.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"

--- a/recipes-graphics/vulkan/vulkan-headers_1.3.247.bb
+++ b/recipes-graphics/vulkan/vulkan-headers_1.3.247.bb
@@ -1,5 +1,8 @@
 require vulkan-headers.inc
 
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
 SRCREV = "95a13d7b7118d3824f0ef236bb0438d9d51f3634"
 PV = "1.3.247"
 

--- a/recipes-graphics/vulkan/vulkan-headers_1.3.260.bb
+++ b/recipes-graphics/vulkan/vulkan-headers_1.3.260.bb
@@ -1,5 +1,8 @@
 require vulkan-headers.inc
 
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
 SRCREV = "94bb3c998b9156b9101421f7614617dfcf7f4256"
 PV = "1.3.260"
 


### PR DESCRIPTION
Reason for change : Mapping LIC_FILES_CHKSUM to valid license file
Test Procedure: Build and Verify
Risks: Low