### PR TITLE
RDKOSS-1001: Change PV to 4.13.2 for enable breakpad mixedmode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -7,7 +7,7 @@ PACKAGE_ARCH = "${OSS_LAYER_ARCH}"
 inherit packagegroup
 
 
-PV = "4.13.0"
+PV = "4.13.2"
 PR = "r0"
 
 # poky components


### PR DESCRIPTION
RDKOSS-1001: Change PV to 4.13.2 for enable breakpad mixedmode patch for multilib platforms