### PR TITLE
RDKOSS-998:libidn2 component license issue

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,4 +20,7 @@ BBMASK .= "|meta-openembedded/meta-oe/recipes-devtools/giflib/giflib_5.1.4.bb"
 BBMASK .= "|poky/meta/recipes-graphics/jpeg/libjpeg-turbo_2.1.4.bb"
 BBMASK .= "|meta-rdk-oss-reference/recipes-devtools/perl/perl_%.bbappend"
 
+#Mask GPLv3 Component
+BBMASK .= "|poky/meta/recipes-extended/libidn/libidn2_.*\.bb"
+
 PREBUILT_NATIVE_PKG_EXCLUSION_LIST:append = " opkg-native"

--- a/recipes-core/packagegroups/packagegroup-oss-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-oss-layer.bb
@@ -82,7 +82,6 @@ RDEPENDS:${PN} = "\
      libgpg-error \
      libgudev \
      libical \
-     libidn2 \
      libinput \
      libjpeg \
      libmd \

--- a/recipes-support/curl/curl_7.82%.bbappend
+++ b/recipes-support/curl/curl_7.82%.bbappend
@@ -15,6 +15,9 @@ EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'largefile', 'ac_cv_siz
 PACKAGECONFIG:append = " ipv6 "
 PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"
 
+PACKAGECONFIG:remove = "libidn"
+EXTRA_OECONF:append = " --without-libidn2"
+
 inherit ptest
 
 do_compile_ptest() {


### PR DESCRIPTION
Reason for change: Remove the libidn library from the curl as it is gplv3 licensed.
Test Procedure: Ensure RDK build and no functionality breakage Risks: Medium
Priority: Medium

Signed-off-by: sktraja <sk.traj44@gmail.com>