### PR TITLE
RDKOSS-957 : Vulkan 1.4.341 support

### DIFF
--- a/recipes-graphics/vulkan/vulkan-headers_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-headers_1.4.341.0.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Vulkan Header files and API registry"
+DESCRIPTION = "Vulkan is a 3D graphics and compute API providing cross-platform access \
+to modern GPUs with low overhead and targeting realtime graphics applications such as \
+games and interactive media. This package contains the development headers \
+for packages wanting to make use of Vulkan."
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Headers"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0 & MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=1bc355d8c4196f774c8b87ed1a8dd625"
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Headers.git;branch=main;protocol=https"
+
+SRCREV = "b5c8f996196ba4aa6d8f97e52b5d3b6e70f7e4e2"
+
+inherit cmake
+
+FILES:${PN} += "${datadir}/vulkan"
+RDEPENDS:${PN} += "python3-core"
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools,
+# vulkan-validation-layers, vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"

--- a/recipes-graphics/vulkan/vulkan-loader_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-loader_1.4.341.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "3D graphics and compute API common loader"
+DESCRIPTION = "Vulkan is a new generation graphics and compute API \
+that provides efficient access to modern GPUs. These packages \
+provide only the common vendor-agnostic library loader, headers and \
+the vulkaninfo utility."
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Loader"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7dbefed23242760aa3475ee42801c5ac"
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Loader.git;branch=main;protocol=https"
+SRCREV = "32fcb949e253cbeb40cda7ea76122b492db579ae"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+inherit cmake features_check pkgconfig
+
+DEPENDS += "vulkan-headers"
+
+EXTRA_OECMAKE = "\
+                 -DBUILD_TESTS=OFF \
+                 -DPYTHON_EXECUTABLE=${HOSTTOOLS_DIR}/python3 \
+                 -DASSEMBLER_WORKS=FALSE \
+                 -DVulkanHeaders_INCLUDE_DIR=${STAGING_INCDIR} \
+                 -DVulkanRegistry_DIR=${RECIPE_SYSROOT}/${datadir} \
+                 "
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[x11] = "-DBUILD_WSI_XLIB_SUPPORT=ON -DBUILD_WSI_XCB_SUPPORT=ON, -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF, libxcb libx11 libxrandr"
+PACKAGECONFIG[wayland] = "-DBUILD_WSI_WAYLAND_SUPPORT=ON, -DBUILD_WSI_WAYLAND_SUPPORT=OFF, wayland"
+
+RRECOMMENDS:${PN} = "virtual-vulkan-icd"
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools,
+# vulkan-validation-layers, vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"

--- a/recipes-graphics/vulkan/vulkan-samples_git.bb
+++ b/recipes-graphics/vulkan/vulkan-samples_git.bb
@@ -1,0 +1,36 @@
+SUMMARY = "The Vulkan Samples is collection of resources to help develop optimized Vulkan applications."
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Samples/issues"
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=48aa35cefb768436223a6e7f18dc2a2a"
+
+SRC_URI = "gitsm://github.com/KhronosGroup/Vulkan-Samples.git;branch=main;protocol=https;lfs=0 \
+           "
+
+UPSTREAM_CHECK_COMMITS = "1"
+SRCREV = "fa2cf45adde08778d1e8f885f21f934f56d9eb58"
+
+UPSTREAM_CHECK_GITTAGREGEX = "These are not the releases you're looking for"
+
+REQUIRED_DISTRO_FEATURES = 'vulkan'
+
+# Avoid erroring on including <ciso646> instead of <version> in c++17
+CXXFLAGS += "-Wno-error=cpp"
+inherit cmake features_check
+
+FILES:${PN} += "${datadir}"
+
+# Binaries built with PCH enabled don't appear reproducible, differing results were seen
+# from some builds depending on the point the PCH was compiled. Disable it to be
+# deterministic
+EXTRA_OECMAKE += "-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON"
+
+# This needs to be specified explicitly to avoid xcb/xlib dependencies
+EXTRA_OECMAKE += "-DVKB_WSI_SELECTION=D2D"
+
+# Clang is fussy about incompatible options on aarch64/x86_64
+# x86_64-poky-linux-clang++: error: overriding '-ffp-model=precise' option with '-ffp-contract=fast' [-Werror,-Woverriding-option]
+CXXFLAGS:append:toolchain-clang = " -Wno-error=overriding-option"
+
+COMPATIBLE_HOST = "(aarch64|x86_64).*-linux"

--- a/recipes-graphics/vulkan/vulkan-tools_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-tools_1.4.341.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Vulkan Utilities and Tools"
+DESCRIPTION = "Assist development by enabling developers to verify their applications correct use of the Vulkan API."
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Tools"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Tools.git;branch=main;protocol=https"
+SRCREV = "48a4bcbdf619e57204783f8c1a04c76c160ddd5b"
+
+inherit cmake features_check pkgconfig
+ANY_OF_DISTRO_FEATURES = "x11 wayland"
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+DEPENDS += "vulkan-headers vulkan-loader vulkan-volk"
+
+EXTRA_OECMAKE = "\
+                 -DBUILD_TESTS=OFF \
+                 -DBUILD_CUBE=OFF \
+                 -DPYTHON_EXECUTABLE=${HOSTTOOLS_DIR}/python3 \
+                 "
+
+# must choose x11 or wayland or both
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[x11] = "-DBUILD_WSI_XLIB_SUPPORT=ON -DBUILD_WSI_XCB_SUPPORT=ON, -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF, libxcb libx11 libxrandr"
+PACKAGECONFIG[wayland] = "-DBUILD_WSI_WAYLAND_SUPPORT=ON, -DBUILD_WSI_WAYLAND_SUPPORT=OFF, wayland"
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools, spirv-headers, spirv-tools
+# vulkan-validation-layers, vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"

--- a/recipes-graphics/vulkan/vulkan-utility-libraries_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-utility-libraries_1.4.341.0.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Vulkan Utility Libraries"
+DESCRIPTION = "Common libraries created to share code across various \
+Vulkan repositories, solving long standing issues for Vulkan SDK \
+developers and users."
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=4ca2d6799091aaa98a8520f1b793939b"
+
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-Utility-Libraries.git;branch=main;protocol=https"
+SRCREV = "a663eca87ba71294dd4b74ba9d3e64a72d725453"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+DEPENDS = "vulkan-headers"
+
+EXTRA_OECMAKE = "\
+    -DBUILD_TESTS=OFF \
+    "
+
+inherit cmake features_check pkgconfig
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools,
+# vulkan-validation-layers, spirv-headers, spirv-tools,
+# vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"

--- a/recipes-graphics/vulkan/vulkan-validation-layers_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-validation-layers_1.4.341.0.bb
@@ -1,0 +1,49 @@
+SUMMARY = "Vulkan Validation layers"
+DESCRIPTION = "Khronos official Vulkan validation layers to assist developers \
+in verifying that their applications correctly use the Vulkan API"
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/KhronosGroup/Vulkan-ValidationLayers"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0 & MIT & BSL-1.0 "
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b1a17d548e004bfbbfaa0c40988b6b31"
+
+SRC_URI = "git://github.com/KhronosGroup/Vulkan-ValidationLayers.git;branch=main;protocol=https"
+SRCREV = "14de3c0d7b396853d81e6975aad3713984a697a6"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+DEPENDS = "vulkan-headers vulkan-loader spirv-headers spirv-tools glslang vulkan-utility-libraries"
+
+# BUILD_TESTS            - Not required for OE builds
+# USE_ROBIN_HOOD_HASHING - Provides substantial performance improvements on all platforms.
+#                          Yocto project doesn't contain a recipe for package so disabled it.
+EXTRA_OECMAKE = "\
+    -DBUILD_TESTS=OFF \
+    -DUSE_ROBIN_HOOD_HASHING=OFF \
+    -DGLSLANG_INSTALL_DIR=${STAGING_LIBDIR} \
+    -DVULKAN_HEADERS_INSTALL_DIR=${STAGING_EXECPREFIXDIR} \
+    -DSPIRV_HEADERS_INSTALL_DIR=${STAGING_EXECPREFIXDIR} \
+    "
+
+CXXFLAGS:append = " ${@oe.utils.vartrue('DEBUG_BUILD', '-DXXH_NO_INLINE_HINTS=1', '', d)}"
+
+PACKAGECONFIG[x11] = "-DBUILD_WSI_XLIB_SUPPORT=ON -DBUILD_WSI_XCB_SUPPORT=ON, -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_XCB_SUPPORT=OFF, libxcb libx11 libxrandr"
+PACKAGECONFIG[wayland] = "-DBUILD_WSI_WAYLAND_SUPPORT=ON, -DBUILD_WSI_WAYLAND_SUPPORT=OFF, wayland"
+
+PACKAGECONFIG ?= "${@bb.utils.filter('DISTRO_FEATURES', 'x11 wayland', d)}"
+
+inherit cmake features_check pkgconfig
+
+FILES:${PN} += "${datadir}/vulkan"
+
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools,
+# vulkan-validation-layers, spirv-headers, spirv-tools,
+# vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"

--- a/recipes-graphics/vulkan/vulkan-volk_1.4.304.bb
+++ b/recipes-graphics/vulkan/vulkan-volk_1.4.304.bb
@@ -1,0 +1,37 @@
+SUMMARY = "A meta-loader for Vulkan"
+DESCRIPTION = "Volk allows one to dynamically load entrypoints required \
+to use Vulkan without linking to vulkan-1.dll or statically linking Vulkan loader. \
+"
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/zeux/volk"
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=12e6af3a0e2a5e5dbf7796aa82b64626"
+
+S = "${WORKDIR}/git"
+SRC_URI = "git://github.com/zeux/volk.git;branch=master;protocol=https"
+SRCREV = "0b17a763ba5643e32da1b2152f8140461b3b7345"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+DEPENDS = "vulkan-headers"
+
+EXTRA_OECMAKE = "\
+    -DVOLK_INSTALL=ON \
+    "
+
+inherit cmake features_check pkgconfig
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools,
+# vulkan-validation-layers, spirv-headers, spirv-tools,
+# vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
+
+do_install:append() {
+    sed -i -e 's,${STAGING_DIR_TARGET},,g' ${D}${libdir}/cmake/volk/volkTargets.cmake
+}
+

--- a/recipes-graphics/vulkan/vulkan-volk_1.4.341.0.bb
+++ b/recipes-graphics/vulkan/vulkan-volk_1.4.341.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "A meta-loader for Vulkan"
+DESCRIPTION = "Volk allows one to dynamically load entrypoints required \
+to use Vulkan without linking to vulkan-1.dll or statically linking Vulkan loader. \
+"
+HOMEPAGE = "https://www.khronos.org/vulkan/"
+BUGTRACKER = "https://github.com/zeux/volk"
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=cfcbdd69e15396e371f639c69acf40bf"
+
+SRC_URI = "git://github.com/zeux/volk.git;branch=master;protocol=https"
+SRCREV = "d979819fd03de3a7606d6e23d6ff4968942599da"
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+DEPENDS = "vulkan-headers"
+
+EXTRA_OECMAKE = "\
+    -DVOLK_INSTALL=ON \
+    "
+
+inherit cmake features_check pkgconfig
+
+# These recipes need to be updated in lockstep with each other:
+# glslang, vulkan-headers, vulkan-loader, vulkan-tools,
+# vulkan-validation-layers, spirv-headers, spirv-tools,
+# vulkan-utility-libraries, vulkan-volk.
+# The tags versions should always be sdk-x.y.z, as this is what
+# upstream considers a release.
+UPSTREAM_CHECK_GITTAGREGEX = "sdk-(?P<pver>\d+(\.\d+)+)"
+
+do_install:append() {
+    sed -i -e 's,${STAGING_DIR_TARGET},,g' ${D}${libdir}/cmake/volk/volkTargets.cmake
+}


### PR DESCRIPTION
Reason for change : Adding support for Vulkan 1.4.341 and 1.4.304
Test Procedure: Build and Verify
Risks: Low