### PR TITLE
RDKBACCL-1934 : Build ap extender core-image-minimal profile

### DIFF
--- a/PACKAGE_DEBUG_SPLIT_STYLE:wrynose
+++ b/PACKAGE_DEBUG_SPLIT_STYLE:wrynose
@@ -1,0 +1,2 @@
+INSANE_SKIP:${PN} += "installed-vs-shipped"
+CFLAGS:append = " -DNDBM_H_USES_PROTOTYPES"

--- a/recipes-core/kbd/kbd_%.bbappend
+++ b/recipes-core/kbd/kbd_%.bbappend
@@ -10,6 +10,7 @@ inherit ptest
 
 RDEPENDS:${PN}-ptest += "bash"
 
+PACKAGES = "${PN}"
 do_compile_ptest() {
     # update DATADIR in Makefile
     sed -i 's,-DDATADIR=.*,-DDATADIR=\\\"${PTEST_PATH}/tests\\\" \\,g' ${B}/tests/libkeymap/Makefile
@@ -93,3 +94,5 @@ do_install_ptest() {
     # update PTEST_PATH in run-ptest
     sed -i "s#@PTEST_PATH@#${PTEST_PATH}#g" ${D}${PTEST_PATH}/run-ptest
 }
+PACKAGE_DEBUG_SPLIT_STYLE:wrynose = "debug-without-src"
+INSANE_SKIP:${PN} += "installed-vs-shipped"

--- a/recipes-devtools/perl/perl_%.bbappend
+++ b/recipes-devtools/perl/perl_%.bbappend
@@ -36,3 +36,4 @@ do_configure:prepend() {
     sed -i 's/i_ndbm=define/i_ndbm=undef/g' ${S}/hints/linux.sh || true
     sed -i 's/i_dbm=define/i_dbm=undef/g' ${S}/hints/linux.sh || true
 }
+CFLAGS:append = " -DNDBM_H_USES_PROTOTYPES"


### PR DESCRIPTION
Reason for change : fixing build issues wrt kbd and perl 
Test procedure: build wrynose
Risks: None
Priority:P1