### PR TITLE
RDKOSS-1062: Breakpad upgrade

### DIFF
--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Fixed-missing-include-for-std-find_if.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Fixed-missing-include-for-std-find_if.patch
@@ -1,0 +1,31 @@
+From 45ea097e864e566771d756c92619e984815acd1e Mon Sep 17 00:00:00 2001
+From: Nathan Moinvaziri <nathan@nathanm.com>
+Date: Tue, 19 Dec 2023 14:35:05 -0800
+Subject: [PATCH] Fixed missing include for std::find_if.
+
+Throws an error when compiling on Windows.
+
+Upstream-Status: Backport [https://github.com/google/breakpad/commit/898a997855168c0e6a689072fefba89246271a5d]
+Change-Id: Ieb34c00cf199aaa1b45a440086c48b8ed363b3c7
+Reviewed-on: https://chromium-review.googlesource.com/c/breakpad/breakpad/+/5137658
+Reviewed-by: Ivan Penkov <ivanpe@chromium.org>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/common/module.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/common/module.cc b/src/common/module.cc
+index 0eb5aad8..b6f5da7e 100644
+--- a/src/common/module.cc
++++ b/src/common/module.cc
+@@ -42,6 +42,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
++#include <algorithm>
+ #include <functional>
+ #include <iostream>
+ #include <memory>
+-- 
+2.43.0
+

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Remove-HAVE_GETCONTEXT-check-to-add-local-implementa.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Remove-HAVE_GETCONTEXT-check-to-add-local-implementa.patch
@@ -1,0 +1,49 @@
+From 70441611d4e8200d9d16dfed493873b8c1bb57c5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 15 Mar 2021 11:33:38 -0700
+Subject: [PATCH] Remove HAVE_GETCONTEXT check to add local implementation
+
+On musl getcontext/setcontext APIs are implemented in libucontext which
+can be used
+
+Upstream-Status: Inappropriate [Musl Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Makefile.am | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -529,10 +529,6 @@ src_client_linux_libbreakpad_client_a_SO
+ 	src/common/linux/linux_libc_support.cc \
+ 	src/common/linux/memory_mapped_file.cc \
+ 	src/common/linux/safe_readlink.cc
+-if !HAVE_GETCONTEXT
+-src_client_linux_libbreakpad_client_a_SOURCES += \
+-	src/common/linux/breakpad_getcontext.S
+-endif
+ 
+ # Client tests
+ src_client_linux_linux_dumper_unittest_helper_SOURCES = \
+@@ -580,10 +576,6 @@ src_client_linux_linux_client_unittest_s
+ 	src/processor/minidump.cc \
+ 	src/processor/pathname_stripper.cc \
+ 	src/processor/proc_maps_linux.cc
+-if !HAVE_GETCONTEXT
+-src_client_linux_linux_client_unittest_shlib_SOURCES += \
+-	src/common/linux/breakpad_getcontext.S
+-endif
+ 
+ src_client_linux_linux_client_unittest_shlib_CPPFLAGS = \
+ 	$(AM_CPPFLAGS) $(TEST_CFLAGS)
+@@ -613,10 +605,6 @@ src_client_linux_linux_client_unittest_s
+ 	src/common/string_conversion.o \
+ 	$(TEST_LIBS) \
+ 	$(PTHREAD_CFLAGS) $(PTHREAD_LIBS)
+-if !HAVE_GETCONTEXT
+-src_client_linux_linux_client_unittest_shlib_SOURCES += \
+-	src/common/linux/breakpad_getcontext_unittest.cc
+-endif
+ if ANDROID_HOST
+ src_client_linux_linux_client_unittest_shlib_LDFLAGS += \
+ 	-llog -lm

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Turn-off-sign-compare-for-musl-libc.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0001-Turn-off-sign-compare-for-musl-libc.patch
@@ -1,0 +1,38 @@
+From ab8dcad25d0ac1f3a88814e78794e5d450de15ac Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 14 Sep 2017 23:12:51 -0700
+Subject: [PATCH 1/5] Turn off sign-compare for musl-libc
+
+Fix
+
+../../../../../../../workspace/sources/breakpad/src/client/linux/crash_generation/crash_generation_server.cc:234:14: error:                 comparison of integers of different signs: 'unsigned long' and 'int' [-Werror,-Wsign-compare]                                          hdr = CMSG_NXTHDR(&msg, hdr)) {                                                                                                             ^~~~~~~~~~~~~~~~~~~~~~
+/mnt/a/oe/build/tmp/work/cortexa7hf-neon-vfpv4-bec-linux-musleabi/breakpad/1_1.0+git999-r0/recipe-sysroot/usr/include/sys/socket.h:288:44: note:                                                                                                                                  expanded from macro 'CMSG_NXTHDR'                                                                                                       __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                       1 error generated.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Pending
+
+ src/client/linux/crash_generation/crash_generation_server.cc | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/src/client/linux/crash_generation/crash_generation_server.cc
++++ b/src/client/linux/crash_generation/crash_generation_server.cc
+@@ -230,8 +230,18 @@ CrashGenerationServer::ClientEvent(short
+   // Walk the control payload and extract the file descriptor and validated pid.
+   pid_t crashing_pid = -1;
+   int signal_fd = -1;
++#ifndef __GLIBC__
++  // In musl-libc, CMSG_NXTHDR typecasts char* to cmsghdr* which causes
++  // clang to throw sign-compare warning. This is to suppress the warning
++  // inline.
++  #pragma clang diagnostic push
++  #pragma clang diagnostic ignored "-Wsign-compare"
++#endif
+   for (struct cmsghdr* hdr = CMSG_FIRSTHDR(&msg); hdr;
+        hdr = CMSG_NXTHDR(&msg, hdr)) {
++#ifndef __GLIBC__
++  #pragma clang diagnostic pop
++#endif
+     if (hdr->cmsg_level != SOL_SOCKET)
+       continue;
+     if (hdr->cmsg_type == SCM_RIGHTS) {

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0001-include-sys-reg.h-to-get-__WORDSIZE-on-musl-libc.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0001-include-sys-reg.h-to-get-__WORDSIZE-on-musl-libc.patch
@@ -1,0 +1,28 @@
+From 68580cb62f77117be3164c52abae68f75e8e59a1 Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Sun, 1 Feb 2015 14:26:52 +0100
+Subject: [PATCH 1/3] include <sys/reg.h> to get __WORDSIZE on musl libc
+
+---
+Upstream-Status: Pending
+
+ src/common/linux/elf_core_dump.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/common/linux/elf_core_dump.h
++++ b/src/common/linux/elf_core_dump.h
+@@ -33,10 +33,14 @@
+ #ifndef COMMON_LINUX_ELF_CORE_DUMP_H_
+ #define COMMON_LINUX_ELF_CORE_DUMP_H_
+ 
++#include <config.h>
+ #include <elf.h>
+ #include <limits.h>
+ #include <link.h>
+ #include <stddef.h>
++#ifdef HAVE_SYS_REG_H
++#include <sys/reg.h>
++#endif
+ 
+ #include "common/memory_range.h"
+ 

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0001-lss-Match-syscalls-to-match-musl.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0001-lss-Match-syscalls-to-match-musl.patch
@@ -1,0 +1,58 @@
+From 5f7333e4f7b7485598bd71aa80967e1a16a7f901 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 14 Sep 2017 22:57:52 -0700
+Subject: [PATCH] lss: Match syscalls to match musl
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Pending
+
+ linux_syscall_support.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/linux_syscall_support.h
++++ b/linux_syscall_support.h
+@@ -1006,6 +1006,9 @@ struct kernel_statx {
+ #define FUTEX_TRYLOCK_PI_PRIVATE  (FUTEX_TRYLOCK_PI | FUTEX_PRIVATE_FLAG)
+ #endif
+ 
++#ifndef __NR_fstatat
++#define __NR_fstatat __NR_fstatat64
++#endif
+ 
+ #if defined(__x86_64__)
+ #ifndef ARCH_SET_GS
+@@ -1140,6 +1143,7 @@ struct kernel_statx {
+ #ifndef __NR_getrandom
+ #define __NR_getrandom          355
+ #endif
++
+ /* End of i386 definitions                                                   */
+ #elif defined(__ARM_ARCH_3__) || defined(__ARM_EABI__)
+ #ifndef __NR_setresuid
+@@ -1448,6 +1452,12 @@ struct kernel_statx {
+ #ifndef __NR_getrandom
+ #define __NR_getrandom          318
+ #endif
++#ifndef __NR_pread
++#define __NR_pread __NR_pread64
++#endif
++#ifndef __NR_pwrite
++#define __NR_pwrite __NR_pwrite64
++#endif
+ /* End of x86-64 definitions                                                 */
+ #elif defined(__mips__)
+ #if _MIPS_SIM == _MIPS_SIM_ABI32
+@@ -1633,6 +1643,12 @@ struct kernel_statx {
+ #ifndef __NR_getrandom
+ #define __NR_getrandom          (__NR_Linux + 313)
+ #endif
++
++#undef __NR_pread
++#define __NR_pread __NR_pread64
++#undef __NR_pwrite
++#define __NR_pwrite __NR_pwrite64
++
+ /* End of MIPS (64bit API) definitions */
+ #else
+ #ifndef __NR_setresuid

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0003-Dont-include-stab.h.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0003-Dont-include-stab.h.patch
@@ -1,0 +1,82 @@
+From 569af712da94637091080943f6a0d69ccb35864e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 14 Sep 2017 23:24:08 -0700
+Subject: [PATCH 3/5] Dont include stab.h
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Pending
+
+ src/common/stabs_reader.cc          |  1 -
+ src/common/stabs_reader.h           | 12 +++++++++++-
+ src/common/stabs_reader_unittest.cc |  1 -
+ 3 files changed, 11 insertions(+), 3 deletions(-)
+
+--- a/src/common/stabs_reader.cc
++++ b/src/common/stabs_reader.cc
+@@ -38,7 +38,9 @@
+ #include "common/stabs_reader.h"
+ 
+ #include <assert.h>
++#ifdef HAVE_STAB_H
+ #include <stab.h>
++#endif
+ #include <string.h>
+ 
+ #include <string>
+--- a/src/common/stabs_reader.h
++++ b/src/common/stabs_reader.h
+@@ -54,6 +54,30 @@
+ #elif defined(HAVE_A_OUT_H)
+ #include <a.out.h>
+ #endif
++// Definitions from <stab.h> and <a.out.h> for systems which
++// do not have them
++#ifndef HAVE_A_OUT_H
++#undef N_UNDF
++#define N_UNDF 0x0
++#ifndef N_FUN
++#define N_FUN 0x24
++#endif
++#ifndef N_SLINE
++#define N_SLINE 0x44
++#endif
++#ifndef N_SO
++#define N_SO 0x64
++#endif
++#ifndef N_LSYM
++#define N_LSYM 0x80
++#endif
++#ifndef N_BINCL
++#define N_BINCL 0x82
++#endif
++#ifndef N_SOL
++#define N_SOL 0x84
++#endif
++#endif
+ 
+ #include <string>
+ #include <vector>
+--- a/src/common/stabs_reader_unittest.cc
++++ b/src/common/stabs_reader_unittest.cc
+@@ -36,7 +36,9 @@
+ 
+ #include <assert.h>
+ #include <errno.h>
++#ifdef HAVE_STAB_H
+ #include <stab.h>
++#endif
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/configure.ac
++++ b/configure.ac
+@@ -61,7 +61,7 @@ fi
+ 
+ AC_SYS_LARGEFILE
+ AX_PTHREAD
+-AC_CHECK_HEADERS([a.out.h sys/mman.h sys/random.h])
++AC_CHECK_HEADERS([a.out.h stab.h sys/mman.h sys/random.h])
+ AC_CHECK_FUNCS([arc4random getcontext getrandom memfd_create])
+ AM_CONDITIONAL([HAVE_GETCONTEXT], [test "x$ac_cv_func_getcontext" = xyes])
+ AM_CONDITIONAL([HAVE_MEMFD_CREATE], [test "x$ac_cv_func_memfd_create" = xyes])

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0003-Fix-conflict-between-musl-libc-dirent.h-and-lss.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0003-Fix-conflict-between-musl-libc-dirent.h-and-lss.patch
@@ -1,0 +1,32 @@
+From 7aa266545dabf9934ccd44d4fc836040497159be Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Sun, 1 Feb 2015 13:41:08 +0100
+Subject: [PATCH 3/3] Fix conflict between musl libc <dirent.h> and lss
+
+Include <dirent.h> late to avoid the macro getdents64 in musl
+libc's <dirent.h> to conflict with linux_sycall_support.h.
+---
+Upstream-Status: Pending
+
+ src/client/linux/crash_generation/crash_generation_server.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/src/client/linux/crash_generation/crash_generation_server.cc
++++ b/src/client/linux/crash_generation/crash_generation_server.cc
+@@ -31,7 +31,6 @@
+ #endif
+ 
+ #include <assert.h>
+-#include <dirent.h>
+ #include <fcntl.h>
+ #include <limits.h>
+ #include <poll.h>
+@@ -52,6 +51,8 @@
+ #include "common/linux/guid_creator.h"
+ #include "common/linux/safe_readlink.h"
+ 
++#include <dirent.h>
++
+ static const char kCommandQuit = 'x';
+ 
+ namespace google_breakpad {

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/0004-elf_reader.cc-include-sys-reg.h-to-get-__WORDSIZE-on.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/0004-elf_reader.cc-include-sys-reg.h-to-get-__WORDSIZE-on.patch
@@ -1,0 +1,43 @@
+From 680f9590d19a6e35c7c5587e3f4d8194aab0fcd2 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 14 Sep 2017 23:28:36 -0700
+Subject: [PATCH 4/5] elf_reader.cc: include <sys/reg.h> to get __WORDSIZE on
+ musl libc
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Pending
+
+ src/common/dwarf/elf_reader.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/common/dwarf/elf_reader.cc
++++ b/src/common/dwarf/elf_reader.cc
+@@ -34,12 +34,16 @@
+ #include <config.h>  // Must come first
+ #endif
+ 
++#include <config.h>
+ #include <fcntl.h>
+ #include <limits.h>
+ #include <string.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#ifdef HAVE_SYS_REG_H
++#include <sys/reg.h>
++#endif
+ #include <unistd.h>
+ 
+ #include <algorithm>
+--- a/configure.ac
++++ b/configure.ac
+@@ -61,7 +61,7 @@ fi
+ 
+ AC_SYS_LARGEFILE
+ AX_PTHREAD
+-AC_CHECK_HEADERS([a.out.h stab.h sys/mman.h sys/random.h])
++AC_CHECK_HEADERS([a.out.h stab.h sys/mman.h sys/random.h sys/reg.h])
+ AC_CHECK_FUNCS([arc4random getcontext getrandom memfd_create])
+ AM_CONDITIONAL([HAVE_GETCONTEXT], [test "x$ac_cv_func_getcontext" = xyes])
+ AM_CONDITIONAL([HAVE_MEMFD_CREATE], [test "x$ac_cv_func_memfd_create" = xyes])

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/mcontext.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/mcontext.patch
@@ -1,0 +1,16 @@
+map the mcontext_t structure for musl
+
+Upstream-Status: Inappropriate [need to consider Android]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/src/client/linux/minidump_writer/linux_core_dumper.cc
++++ b/src/client/linux/minidump_writer/linux_core_dumper.cc
+@@ -214,7 +214,7 @@ bool LinuxCoreDumper::EnumerateThreads()
+         info.tgid = status->pr_pgrp;
+         info.ppid = status->pr_ppid;
+ #if defined(__mips__)
+-# if defined(__ANDROID__)
++# if defined(__ANDROID__) || !defined(__GLIBC__)
+         for (int i = EF_R0; i <= EF_R31; i++)
+           info.mcontext.gregs[i - EF_R0] = status->pr_reg[i];
+ # else  // __ANDROID__

--- a/recipes-devtools/breakpad/2023.06.01/breakpad/mips_asm_sgidefs.patch
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad/mips_asm_sgidefs.patch
@@ -1,0 +1,19 @@
+Upstream-Status: Pending
+
+--- a/linux_syscall_support.h
++++ b/linux_syscall_support.h
+@@ -119,14 +119,7 @@ extern "C" {
+ 
+ #ifdef __mips__
+ /* Include definitions of the ABI currently in use.                          */
+-#ifdef __ANDROID__
+-/* Android doesn't have sgidefs.h, but does have asm/sgidefs.h,
+- * which has the definitions we need.
+- */
+ #include <asm/sgidefs.h>
+-#else
+-#include <sgidefs.h>
+-#endif
+ #endif
+ #endif
+ 

--- a/recipes-devtools/breakpad/2023.06.01/breakpad_2023.06.01.inc
+++ b/recipes-devtools/breakpad/2023.06.01/breakpad_2023.06.01.inc
@@ -1,0 +1,129 @@
+# breakpad_2023.06.01.bb https://github.com/rdkcentral/meta-rdk-oss-reference, scarthgap, July 24, 2026
+
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+# Applications using this library needs to add link against libbreakpad_client.a.
+
+SUMMARY = "An open-source multi-platform crash reporting system"
+DESCRIPTION = "Breakpad is a library and tool suite that allows you to distribute an application to users with compiler-provided debugging information removed, record crashes in compact \"minidump\" files, send them back to your server, and produce C and C++ stack traces from these minidumps. "
+HOMEPAGE = "https://code.google.com/p/google-breakpad/"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=07aeb530115539d62cacf9942fa60cac"
+SECTION = "libs"
+
+inherit autotools
+
+DEPENDS += "zlib"
+DEPENDS:append:libc-musl = " libucontext"
+
+BBCLASSEXTEND = "native"
+
+PE = "2"
+
+SRCREV_FORMAT = "breakpad_gtest_protobuf_lss"
+
+SRCREV_breakpad = "8988364bcddd9b194b0bf931c10bc125987330ed"
+#v1.11.0
+SRCREV_gtest = "e2239ee6043f73722e7aa812a459f54a28552929"
+SRCREV_protobuf = "cb6dd4ef5f82e41e06179dcd57d3b1d9246ad6ac"
+SRCREV_lss = "9719c1e1e676814c456b55f5f070eabad6709d31"
+
+SRC_URI = "git://github.com/google/breakpad;name=breakpad;branch=main;protocol=https \
+           git://github.com/google/googletest.git;destsuffix=git/src/testing/gtest;name=gtest;branch=main;protocol=https \
+           git://github.com/protocolbuffers/protobuf.git;destsuffix=git/src/third_party/protobuf/protobuf;name=protobuf;branch=main;protocol=https \
+           git://chromium.googlesource.com/linux-syscall-support;protocol=https;branch=main;destsuffix=git/src/third_party/lss;name=lss \
+           file://0001-include-sys-reg.h-to-get-__WORDSIZE-on-musl-libc.patch \
+           file://0003-Fix-conflict-between-musl-libc-dirent.h-and-lss.patch \
+           file://0001-Turn-off-sign-compare-for-musl-libc.patch \
+           file://0003-Dont-include-stab.h.patch \
+           file://0004-elf_reader.cc-include-sys-reg.h-to-get-__WORDSIZE-on.patch \
+           file://mcontext.patch \
+           file://0001-Remove-HAVE_GETCONTEXT-check-to-add-local-implementa.patch \
+           file://0001-Fixed-missing-include-for-std-find_if.patch \
+           file://0001-lss-Match-syscalls-to-match-musl.patch;patchdir=src/third_party/lss \
+           file://mips_asm_sgidefs.patch;patchdir=src/third_party/lss \
+"
+S = "${WORKDIR}/git"
+
+CXXFLAGS += "-D_GNU_SOURCE"
+LDFLAGS:append:libc-musl = " -lucontext"
+
+COMPATIBLE_HOST:powerpc = "null"
+COMPATIBLE_HOST:powerpc64 = "null"
+COMPATIBLE_HOST:powerpc64le = "null"
+COMPATIBLE_HOST:riscv64 = "null"
+COMPATIBLE_HOST:riscv32 = "null"
+
+do_install:append() {
+        install -d ${D}${includedir}
+        install -d ${D}${includedir}/breakpad
+
+        install -d ${D}${includedir}/breakpad/client/linux/crash_generation
+        install -m 0644 ${S}/src/client/linux/crash_generation/crash_generation_client.h  ${D}${includedir}/breakpad/client/linux/crash_generation/crash_generation_client.h
+
+        install -d ${D}${includedir}/breakpad/client/linux/handler/
+        install -m 0644 ${S}/src/client/linux/handler/exception_handler.h ${D}${includedir}/breakpad/client/linux/handler/exception_handler.h
+        install -m 0644 ${S}/src/client/linux/handler/minidump_descriptor.h ${D}${includedir}/breakpad/client/linux/handler/minidump_descriptor.h
+
+        install -d ${D}${includedir}/breakpad/client/linux/dump_writer_common
+        install -m 0644 ${S}/src/client/linux/dump_writer_common/mapping_info.h ${D}${includedir}/breakpad/client/linux/dump_writer_common/mapping_info.h
+        install -m 0644 ${S}/src/client/linux/dump_writer_common/thread_info.h ${D}${includedir}/breakpad/client/linux/dump_writer_common/thread_info.h
+        install -m 0644 ${S}/src/client/linux/dump_writer_common/raw_context_cpu.h ${D}${includedir}/breakpad/client/linux/dump_writer_common/raw_context_cpu.h
+
+        install -d ${D}${includedir}/breakpad/client/linux/minidump_writer
+        install -m 0644 ${S}/src/client/linux/minidump_writer/linux_dumper.h ${D}${includedir}/breakpad/client/linux/minidump_writer/linux_dumper.h
+        install -m 0644 ${S}/src/client/linux/minidump_writer/minidump_writer.h ${D}${includedir}/breakpad/client/linux/minidump_writer/minidump_writer.h
+
+        install -d ${D}${includedir}/breakpad/common
+        install -m 0644 ${S}/src/common/memory_allocator.h ${D}${includedir}/breakpad/common/memory_allocator.h
+        install -m 0644 ${S}/src/common/scoped_ptr.h ${D}${includedir}/breakpad/common/scoped_ptr.h
+        install -m 0644 ${S}/src/common/using_std_string.h ${D}${includedir}/breakpad/common/using_std_string.h
+
+        install -d ${D}${includedir}/breakpad/google_breakpad/common
+        install -m 0644 ${S}/src/google_breakpad/common/breakpad_types.h ${D}${includedir}/breakpad/google_breakpad/common/breakpad_types.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_format.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_format.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_amd64.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_amd64.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_arm.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_arm.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_arm64.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_arm64.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_mips.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_mips.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_ppc64.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_ppc64.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_ppc.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_ppc.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_sparc.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_sparc.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_cpu_x86.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_cpu_x86.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_exception_linux.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_exception_linux.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_exception_mac.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_exception_mac.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_exception_ps3.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_exception_ps3.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_exception_solaris.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_exception_solaris.h
+        install -m 0644 ${S}/src/google_breakpad/common/minidump_exception_win32.h ${D}${includedir}/breakpad/google_breakpad/common/minidump_exception_win32.h
+
+        install -d ${D}${includedir}/breakpad/third_party/lss
+        install -m 0644 ${S}/src/third_party/lss/linux_syscall_support.h ${D}${includedir}/breakpad/third_party/lss/linux_syscall_support.h
+}
+
+PACKAGES =+ "${PN}-minidump-upload ${PN}-sym-upload"
+
+FILES:${PN}-minidump-upload = "${bindir}/minidump_upload"
+FILES:${PN}-sym-upload = "${bindir}/sym_upload"
+
+
+SYSROOT_PREPROCESS_FUNCS += "breakpad_populate_sysroot"
+breakpad_populate_sysroot() {
+        sysroot_stage_dir ${D}/usr/include ${SYSROOT_DESTDIR}/usr/include
+        sysroot_stage_dir ${D}/usr/lib ${SYSROOT_DESTDIR}/usr/lib
+        sysroot_stage_dir ${D}/usr/lib ${SYSROOT_DESTDIR}/usr/lib
+}
+
+# Fails to build with thumb-1 (qemuarm)
+#| {standard input}: Assembler messages:
+#| {standard input}:2178: Error: selected processor does not support Thumb mode `it ne'
+#| {standard input}:2179: Error: Thumb does not support conditional execution
+#| {standard input}:2180: Error: selected processor does not support Thumb mode `it eq'
+#| {standard input}:2181: Error: Thumb does not support conditional execution
+#| {standard input}:2183: Error: lo register required -- `str ip,[r1,#-4]!'
+#| {standard input}:2184: Error: Thumb does not support this addressing mode -- `str r6,[r1,#-4]!'
+#| {standard input}:2191: Error: lo register required -- `ldr pc,[sp]'
+#| make: *** [src/client/linux/handler/exception_handler.o] Error 1
+ARM_INSTRUCTION_SET:armv5 = "arm"
+ARM_INSTRUCTION_SET:armv4 = "arm"
+
+TOOLCHAIN = "gcc"

--- a/recipes-devtools/breakpad/breakpad_2025.02.25.bb
+++ b/recipes-devtools/breakpad/breakpad_2025.02.25.bb
@@ -1,0 +1,38 @@
+#
+# Based on breakpad_2023.06.01.bb https://github.com/rdkcentral/meta-rdk-oss-reference, scarthgap branch, July 24, 2026
+#
+include 2023.06.01/breakpad_2023.06.01.inc
+FILESEXTRAPATHS:prepend := "${THISDIR}/2023.06.01/breakpad:"
+
+# The latest rev without C++20 dep
+SRCREV_breakpad = "2c736308b5a4c7a8371fa3a3e434f551eddd17c9"
+SRC_URI:remove = "file://0001-Fixed-missing-include-for-std-find_if.patch"
+# Fix off_t type size difference across API boundary
+SRC_URI  += "file://breakpad-stable-size_limit-abi-int64.patch"
+
+
+SRC_URI += "file://breakpad_disable_format_macros_check.patch "
+SRC_URI += "file://Set-objects-base-name-as-a-module-name.patch"
+
+# TODO : check if still needed. It provides new APIs so drop if all builds pass
+#SRC_URI += "file://0001_google-breakpad_comcast_dunfell.patch "
+
+SRC_URI:append:class-target = " file://0003-handler-child-process-hang-fix_kirkstone.patch"
+
+SRC_URI += "${@bb.utils.contains('TUNE_FEATURES','bigendian','','file://multi-node-header-check-for-build-id_dunfell.patch',d)}"
+
+SRC_URI += "file://custom-minidump-id.patch"
+SRC_URI += "file://breakpad2_1-processname.patch"
+
+PACKAGES =+ "${PN}-stackwalk ${PN}-binaries"
+
+# uncomment this line to get minidump_stackwalk in the image
+# RDEPENDS:breakpad += "${PN}-stackwalk"
+
+FILES:${PN}-stackwalk = "${bindir}/minidump_stackwalk"
+FILES:${PN}-binaries = "${bindir}/*"
+
+RDEPENDS:${PN}-dev = ""
+RDEPENDS:${PN}-staticdev = ""
+
+BBCLASSEXTEND:append = " nativesdk"

--- a/recipes-devtools/breakpad/files/breakpad-stable-size_limit-abi-int64.patch
+++ b/recipes-devtools/breakpad/files/breakpad-stable-size_limit-abi-int64.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+Date: Fri, 24 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Use fixed-width int64_t for public size_limit to stabilize ABI
+
+The public client headers expose the minidump size limit as `off_t`
+(MinidumpDescriptor::size_limit_ and the WriteMinidump() overloads).
+Because breakpad enables Large File Support for its own build via
+AC_SYS_LARGEFILE (and, since commit f5123d71, includes <config.h> at the
+top of every .cc), `off_t` is 64-bit inside libbreakpad_client on 32-bit
+targets. A consumer that includes these headers without the identical
+_FILE_OFFSET_BITS setting sees `off_t` as 32-bit, so
+sizeof(MinidumpDescriptor) and the WriteMinidump() argument layout
+disagree across the library boundary. On 32-bit this corrupts the
+stack-allocated descriptor and aborts (SIGABRT) at handler installation
+time.
+
+Store and pass the size limit as a fixed-width int64_t in the public API
+so the layout no longer depends on the consumer's _FILE_OFFSET_BITS.
+int64_t is byte-identical to the LFS off_t breakpad already uses
+internally, so this is behaviour-neutral: the value is only ever compared
+and copied, never passed to an off_t syscall. Internal-only state
+(MinidumpDumper::minidump_size_limit_, WriteMinidumpImpl) keeps off_t, and
+AC_SYS_LARGEFILE is retained so the internal off_t stays 64-bit.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrzej Surdej <Andrzej_Surdej@comcast.com>
+
+---
+ src/client/linux/handler/minidump_descriptor.h      | 4 ++--
+ src/client/linux/minidump_writer/minidump_writer.h  | 4 ++--
+ src/client/linux/minidump_writer/minidump_writer.cc | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/client/linux/handler/minidump_descriptor.h b/src/client/linux/handler/minidump_descriptor.h
+--- a/src/client/linux/handler/minidump_descriptor.h
++++ b/src/client/linux/handler/minidump_descriptor.h
+@@ -109,8 +109,8 @@
+   // Should be called from a normal context: this methods uses the heap.
+   void UpdatePath();
+ 
+-  off_t size_limit() const { return size_limit_; }
+-  void set_size_limit(off_t limit) { size_limit_ = limit; }
++  int64_t size_limit() const { return size_limit_; }
++  void set_size_limit(int64_t limit) { size_limit_ = limit; }
+ 
+   uintptr_t address_within_principal_mapping() const {
+     return address_within_principal_mapping_;
+@@ -163,7 +163,7 @@
+   // context.
+   const char* c_path_;
+ 
+-  off_t size_limit_;
++  int64_t size_limit_;
+ 
+   // This member points somewhere into the main module for this
+   // process (the module that is considerered interesting for the
+diff --git a/src/client/linux/minidump_writer/minidump_writer.h b/src/client/linux/minidump_writer/minidump_writer.h
+--- a/src/client/linux/minidump_writer/minidump_writer.h
++++ b/src/client/linux/minidump_writer/minidump_writer.h
+@@ -115,15 +115,15 @@
+                    bool sanitize_stacks = false);
+ 
+ // These overloads also allow passing a file size limit for the minidump.
+-bool WriteMinidump(const char* minidump_path, off_t minidump_size_limit,
++bool WriteMinidump(const char* minidump_path, int64_t minidump_size_limit,
+                    pid_t crashing_process,
+                    const void* blob, size_t blob_size,
+                    const MappingList& mappings,
+                    const AppMemoryList& appdata,
+                    bool skip_stacks_if_mapping_unreferenced = false,
+                    uintptr_t principal_mapping_address = 0,
+                    bool sanitize_stacks = false);
+-bool WriteMinidump(int minidump_fd, off_t minidump_size_limit,
++bool WriteMinidump(int minidump_fd, int64_t minidump_size_limit,
+                    pid_t crashing_process,
+                    const void* blob, size_t blob_size,
+                    const MappingList& mappings,
+diff --git a/src/client/linux/minidump_writer/minidump_writer.cc b/src/client/linux/minidump_writer/minidump_writer.cc
+--- a/src/client/linux/minidump_writer/minidump_writer.cc
++++ b/src/client/linux/minidump_writer/minidump_writer.cc
+@@ -1570,7 +1570,7 @@
+                            sanitize_stacks);
+ }
+ 
+-bool WriteMinidump(const char* minidump_path, off_t minidump_size_limit,
++bool WriteMinidump(const char* minidump_path, int64_t minidump_size_limit,
+                    pid_t crashing_process,
+                    const void* blob, size_t blob_size,
+                    const MappingList& mappings,
+@@ -1586,7 +1586,7 @@
+                            sanitize_stacks);
+ }
+ 
+-bool WriteMinidump(int minidump_fd, off_t minidump_size_limit,
++bool WriteMinidump(int minidump_fd, int64_t minidump_size_limit,
+                    pid_t crashing_process,
+                    const void* blob, size_t blob_size,
+                    const MappingList& mappings,


### PR DESCRIPTION
Upgrade breakpad module to the latest rev without C++20 dep. Use upstream recipe 2023/06/01 from Yocto 5 (scarthgap) branch as baseline.

Leave previous breakpad_git recipe as fallback.

Dropped Comcast paches:
breakpad_mixedmode_fpregs_git.patch - fixed upstream 0001_google-breakpad_comcast_dunfell.patch - not needed for RDK-E breakpad_allocator_gcc11.patch - part of upstream
Add_support_for_compressed_section_to_dump_symbols_kirk.patch - part of upstream

Change-Id: I7eaa4bd97b5d1a682ace0d2dd77f53a7a5dc1b67