### PR TITLE
RDKMVE-3086: Westeros refactoring and consumption from OSS layer

### DIFF
--- a/recipes-graphics/westeros/westeros.inc
+++ b/recipes-graphics/westeros/westeros.inc
@@ -4,7 +4,7 @@ PV = "1.0+gitr${SRCPV}"
 
 #For Westeros recipe
 WESTEROS_URI ?= "git://github.com/rdkcentral/westeros;protocol=https;nobranch=1;name=westeros"
-SRCREV_westeros ?= "2.1.1"
+SRCREV_westeros ?= "2.1.2"
 
 #For westeros-sink
 WESTEROS_SINK_URI ?= "git://github.com/rdkcentral/westeros-sink;protocol=https;nobranch=1;name=westeros-sink"
@@ -12,7 +12,7 @@ SRCREV_westeros-sink ?= "2.1.1"
 
 #For essos
 ESSOS_URI ?= "git://github.com/rdkcentral/essos;protocol=https;nobranch=1;name=essos"
-SRCREV_essos ?= "2.1.1"
+SRCREV_essos ?= "2.1.2"
 
 LICENSE_LOCATION ?= "${S}/LICENSE"
 LIC_FILES_CHKSUM ?= "file://${LICENSE_LOCATION};md5=8fb65319802b0c15fc9e0835350ffa02"


### PR DESCRIPTION
Reason for change:  OSS release 4.14.0 has westeros refactoring changes incorporated,We need to use that in community builds and move to new westeros repos hosted in github.

Test Procedure: Build and verify

Risks: Low