### PR TITLE
RDKOSS-1105: Removing auth_alg for WPA2/WPA3-PT

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager/Removing_auth_alg_entry_for_WPA3_PT.patch
+++ b/recipes-connectivity/networkmanager/networkmanager/Removing_auth_alg_entry_for_WPA3_PT.patch
@@ -1,0 +1,48 @@
+Subject: Disable auth_alg entry for WPA3-PT and WPA2 in NetworkManager
+Description: Disable auth_alg entry for WPA3-PT and WPA2 in new connection profile. 
+This prevents NetworkManager from adding auth_alg=open in new connection profile
+and passing auth_alg to supplicant.
+
+Upstream-Status: Pending
+
+Signed-off-by: Devika Jaladi <Devika_Jaladi@cable.comcast.com>
+Index: NetworkManager-1.43.7/src/core/devices/wifi/nm-wifi-utils.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/devices/wifi/nm-wifi-utils.c
++++ NetworkManager-1.43.7/src/core/devices/wifi/nm-wifi-utils.c
+@@ -819,8 +819,6 @@ nm_wifi_utils_complete_connection(GBytes
+         g_object_set(s_wsec,
+                      NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,
+                      nm_streq0(key_mgmt, "sae") ? "sae" : "wpa-psk",
+-                     NM_SETTING_WIRELESS_SECURITY_AUTH_ALG,
+-                     "open",
+                      NULL);
+     } else if (nm_streq0(key_mgmt, "sae") || (ap_rsn_flags & NM_802_11_AP_SEC_KEY_MGMT_SAE)) {
+         g_object_set(s_wsec, NM_SETTING_WIRELESS_SECURITY_KEY_MGMT, "sae", NULL);
+@@ -833,8 +831,6 @@ nm_wifi_utils_complete_connection(GBytes
+         g_object_set(s_wsec,
+                      NM_SETTING_WIRELESS_SECURITY_KEY_MGMT,
+                      "wpa-psk",
+-                     NM_SETTING_WIRELESS_SECURITY_AUTH_ALG,
+-                     "open",
+                      NULL);
+         /* Leave proto/pairwise/group as client set them; if they are unset the
+          * supplicant will figure out the best combination at connect time.
+Index: NetworkManager-1.43.7/src/core/supplicant/nm-supplicant-config.c
+===================================================================
+--- NetworkManager-1.43.7.orig/src/core/supplicant/nm-supplicant-config.c
++++ NetworkManager-1.43.7/src/core/supplicant/nm-supplicant-config.c
+@@ -966,8 +966,11 @@ nm_supplicant_config_add_setting_wireles
+         return FALSE;
+ 
+     auth_alg = nm_setting_wireless_security_get_auth_alg(setting);
+-    if (!add_string_val(self, auth_alg, "auth_alg", TRUE, NULL, error))
+-        return FALSE;
++    // For SAE and WPA-PSK, do not force auth_alg into supplicant config.
++    if (!NM_IN_STRSET(key_mgmt, "sae", "wpa-psk")) {
++        if (!add_string_val(self, auth_alg, "auth_alg", TRUE, NULL, error))
++            return FALSE;
++    }
+ 
+     psk = nm_setting_wireless_security_get_psk(setting);
+     if (psk) {

--- a/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
+++ b/recipes-connectivity/networkmanager/networkmanager_1.43.7.bb
@@ -34,6 +34,7 @@ SRC_URI = " \
     file://dnsmasq-logging.conf \
     file://NM_autoconnect_retry.patch \
     file://NM_dynamicDNS.patch \
+    file://Removing_auth_alg_entry_for_WPA3_PT.patch \
 "
 
 SRC_URI[sha256sum] = "eb4dd6311f4dbf8b080439a65a3dd0db4fddbd3ebd1ea45994c31a497bf75885"


### PR DESCRIPTION
RDKOSS-1105: Removing auth_alg for WPA2/WPA3-PT
Reason for change: Gnome NetworkManager setting auth_alg parameter
in connection profile when AP is in WPA3-PT.
Test Procedure: Refer ticket
Priority: p0
Risks: medium

Signed-off-by: Devika Jaladi [djalad690@cable.comcast.com](mailto:djalad690@cable.comcast.com)